### PR TITLE
modules: better control the startup sequence

### DIFF
--- a/modules/back-compat.nix
+++ b/modules/back-compat.nix
@@ -65,7 +65,11 @@ with lib;
     env.NIXPKGS_PATH = toString pkgs.path;
 
     devshell =
-      { packages = config.packages; }
+      {
+        packages = config.packages;
+        startup.bash_extra = noDepEntry config.bash.extra;
+        interactive.bash_interactive = noDepEntry config.bash.interactive;
+      }
       // (lib.optionalAttrs (config.motd != null) { motd = config.motd; })
       // (lib.optionalAttrs (config.name != null) { name = config.name; })
       # TODO: move bash.extra into the activation script


### PR DESCRIPTION
The new startup sequence allows third-party modules to inject themselves
into the startup sequence.

    [devshell.startup.myscript]
    text = """
    echo My script
    """

The interface is not public yet as it's not 100% settled yet.