### PR TITLE
commands: use the package for name and help defaults

### DIFF
--- a/devshell.toml
+++ b/devshell.toml
@@ -48,8 +48,6 @@ name = "hello"
 command = "echo hello"
 
 [[commands]]
-help = "used to format Nix code"
-name = "nixpkgs-fmt"
 package = "nixpkgs-fmt"
 category = "formatters"
 
@@ -61,6 +59,5 @@ category = "utilites"
 
 [[commands]]
 help = "golang linter"
-name = "golangci-lint"
 package = "golangci-lint"
 category = "linters"

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -181,7 +181,7 @@ in
       type = types.str;
       default = ''
         ${ansi.orange}🔨 Welcome to ${cfg.name}${ansi.reset}
-        $(menu)
+        $(type -p menu &>/dev/null && menu)
       '';
       description = ''
         Message Of The Day.


### PR DESCRIPTION
This allows to just set the package to get it added to the list. Eg:

    [[commands]]
    package = "nixpkgs-fmt"

And get back this in the help menu:

    nixpkgs-fmt - Nix code formatter for nixpkgs

Fixes #57 