### PR TITLE
break back-compat: [[env]]

### DIFF
--- a/devshell.toml
+++ b/devshell.toml
@@ -23,8 +23,9 @@ packages = [
 # Use this section to set environment variables to have in the environment.
 #
 # NOTE: all the values are escaped
-[env]
-GO111MODULE = "on"
+[[env]]
+name = "GO111MODULE"
+value = "on"
 
 # Declare commands that are available in the environment.
 [[commands]]

--- a/modules/back-compat.nix
+++ b/modules/back-compat.nix
@@ -20,21 +20,6 @@ with lib;
       default = "";
     };
 
-    env = mkOption {
-      type = types.attrs;
-      default = { };
-      description = ''
-        Environment variables to add to the environment.
-
-        If the value is null, it will unset the environment variable.
-        Otherwise, the value will be converted to string before being set.
-      '';
-      example = {
-        GO111MODULE = "on";
-        HTTP_PORT = 8080;
-      };
-    };
-
     motd = mkOption {
       internal = true;
       type = types.nullOr types.str;
@@ -57,9 +42,6 @@ with lib;
   # Copy the values over to the devshell module
   config.devshell =
     {
-      env = map
-        (name: { name = name; value = config.env.${name}; })
-        (lib.attrNames config.env);
       packages = config.packages;
       startup.bash_extra = noDepEntry config.bash.extra;
       interactive.bash_interactive = noDepEntry config.bash.interactive;

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -12,23 +12,6 @@ let
   # environment.
   strOrPackage = import ../nix/strOrPackage.nix { inherit lib pkgs; };
 
-  envToBash = { name, value, eval, prefix }@args:
-    let
-      vals = filter (key: args.${key} != null) [ "value" "eval" "prefix" ];
-      valType = head vals;
-    in
-    assert assertMsg ((length vals) > 0) "[[environ]]: ${name} expected one of value, eval or prefix to be set.";
-    assert assertMsg ((length vals) < 2) "[[environ]]: ${name} expected only one of value, eval or prefix to be set. Not ${toString vals}";
-    assert assertMsg (!(name == "PATH" && valType == "value")) "[[environ]]: ${name} should not override the value. Use 'prefix' instead.";
-    if valType == "value" then
-      "export ${name}=${escapeShellArg (toString value)}"
-    else if valType == "eval" then
-      "export ${name}=${eval}"
-    else if valType == "prefix" then
-      ''export ${name}=$(${pkgs.coreutils}/bin/realpath "${prefix}")''${${name}+:''${${name}}}''
-    else
-      throw "BUG in the environ.nix module. This should never be reached.";
-
   # Use this to define a flake app for the environment.
   mkFlakeApp = bin: {
     type = "app";
@@ -62,41 +45,6 @@ let
     };
   };
 
-  envOptions = {
-    name = mkOption {
-      type = types.str;
-      description = "Name of the environment variable";
-    };
-
-    value = mkOption {
-      type = with types; nullOr (oneOf [ str int bool ]);
-      default = null;
-      description = "Shell-escaped value to set";
-    };
-
-    eval = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      description = ''
-        Like value but not evaluated by Bash. This allows to inject other
-        variable names or even commands using the `$()` notation.
-      '';
-      example = "$OTHER_VAR";
-    };
-
-    prefix = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      description = ''
-        Prepend to PATH-like environment variables.
-
-        For example name = "PATH"; prefix = "bin"; will expand the path of
-        ./bin and prepend it to the PATH, separated by ':'.
-      '';
-      example = "bin";
-    };
-  };
-
   # Write a bash profile to load
   envBash = pkgs.writeText "devshell-env.bash" ''
     # Expose the folder that contains the assembled environment.
@@ -107,7 +55,7 @@ let
     PATH=''${PATH#${bashBin}:}
     export PATH=$DEVSHELL_DIR/bin:${bashBin}:$PATH
 
-    ${concatStringsSep "\n" (map envToBash cfg.env)}
+    ${cfg.startup_env}
 
     ${textClosureMap id (addAttributeName "startup" cfg.startup) (attrNames cfg.startup)}
 
@@ -192,36 +140,21 @@ in
       '';
     };
 
-    env = mkOption {
-      type = types.listOf (types.submodule { options = envOptions; });
-      default = [ ];
-      description = ''
-        Add environment variables to the shell.
-      '';
-      example = literalExample ''
-        [
-          {
-            name = "HTTP_PORT";
-            value = 8080;
-          }
-          {
-            name = "PATH";
-            prefix = "bin";
-          }
-          {
-            name = "XDG_CACHE_DIR";
-            eval = "$DEVSHELL_ROOT/.cache";
-          }
-        ]
-      '';
-    };
-
     startup = mkOption {
       type = types.attrsOf (types.submodule { options = entryOptions; });
       default = { };
       internal = true;
       description = ''
         A list of scripts to execute on startup.
+      '';
+    };
+
+    startup_env = mkOption {
+      type = types.str;
+      default = "";
+      internal = true;
+      description = ''
+        Please ignore. Used by the env module.
       '';
     };
 
@@ -277,21 +210,6 @@ in
 
   config.devshell = {
     entrypoint = entrypoint;
-
-    env = [
-      # Expose the path to nixpkgs
-      {
-        name = "NIXPKGS_PATH";
-        value = toString pkgs.path;
-      }
-
-      # This is used by bash-completions to find new completions on demand
-      {
-        name = "XDG_DATA_DIRS";
-        eval =
-          ''$DEVSHELL_DIR/share''${XDG_DATA_DIRS:-:/usr/local/share:/usr/share}''${XDG_DATA_DIRS+:$XDG_DATA_DIRS}'';
-      }
-    ];
 
     startup = {
       load_profiles = noDepEntry ''

--- a/modules/env.nix
+++ b/modules/env.nix
@@ -1,0 +1,100 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  envOptions = {
+    name = mkOption {
+      type = types.str;
+      description = "Name of the environment variable";
+    };
+
+    value = mkOption {
+      type = with types; nullOr (oneOf [ str int bool ]);
+      default = null;
+      description = "Shell-escaped value to set";
+    };
+
+    eval = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Like value but not evaluated by Bash. This allows to inject other
+        variable names or even commands using the `$()` notation.
+      '';
+      example = "$OTHER_VAR";
+    };
+
+    prefix = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Prepend to PATH-like environment variables.
+
+        For example name = "PATH"; prefix = "bin"; will expand the path of
+        ./bin and prepend it to the PATH, separated by ':'.
+      '';
+      example = "bin";
+    };
+  };
+
+  envToBash = { name, value, eval, prefix }@args:
+    let
+      vals = filter (key: args.${key} != null) [ "value" "eval" "prefix" ];
+      valType = head vals;
+    in
+    assert assertMsg ((length vals) > 0) "[[environ]]: ${name} expected one of value, eval or prefix to be set.";
+    assert assertMsg ((length vals) < 2) "[[environ]]: ${name} expected only one of value, eval or prefix to be set. Not ${toString vals}";
+    assert assertMsg (!(name == "PATH" && valType == "value")) "[[environ]]: ${name} should not override the value. Use 'prefix' instead.";
+    if valType == "value" then
+      "export ${name}=${escapeShellArg (toString value)}"
+    else if valType == "eval" then
+      "export ${name}=${eval}"
+    else if valType == "prefix" then
+      ''export ${name}=$(${pkgs.coreutils}/bin/realpath "${prefix}")''${${name}+:''${${name}}}''
+    else
+      throw "BUG in the environ.nix module. This should never be reached.";
+in
+{
+  options.env = mkOption {
+    type = types.listOf (types.submodule { options = envOptions; });
+    default = [ ];
+    description = ''
+      Add environment variables to the shell.
+    '';
+    example = literalExample ''
+      [
+        {
+          name = "HTTP_PORT";
+          value = 8080;
+        }
+        {
+          name = "PATH";
+          prefix = "bin";
+        }
+        {
+          name = "XDG_CACHE_DIR";
+          eval = "$DEVSHELL_ROOT/.cache";
+        }
+      ]
+    '';
+  };
+
+  config = {
+    # Default env
+    env = [
+      # Expose the path to nixpkgs
+      {
+        name = "NIXPKGS_PATH";
+        value = toString pkgs.path;
+      }
+
+      # This is used by bash-completions to find new completions on demand
+      {
+        name = "XDG_DATA_DIRS";
+        eval =
+          ''$DEVSHELL_DIR/share''${XDG_DATA_DIRS:-:/usr/local/share:/usr/share}''${XDG_DATA_DIRS+:$XDG_DATA_DIRS}'';
+      }
+    ];
+
+    devshell.startup_env = concatStringsSep "\n" (map envToBash config.env);
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -6,6 +6,7 @@ let
     ./back-compat.nix
     ./commands.nix
     ./devshell.nix
+    ./env.nix
     ./modules-docs.nix
     {
       # Configure modules-docs

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -16,6 +16,7 @@ in
 { recurseForDerivations = true; }
 // (import ./commands.nix attrs)
 // (import ./devshell.nix attrs)
+// (import ./env.nix attrs)
 // (import ./git-hooks.nix attrs)
 // (import ./modules-docs.nix attrs)
   // { }

--- a/tests/devshell.nix
+++ b/tests/devshell.nix
@@ -21,45 +21,4 @@
       # Adds packages to the PATH
       type -p git
     '';
-
-  # Test the environment variables
-  devshell-env-1 =
-    let
-      shell = devshell.mkShell {
-        devshell.name = "devshell-env-1";
-        devshell.env = [
-          {
-            name = "HTTP_PORT";
-            value = 8080;
-          }
-          {
-            name = "PATH";
-            prefix = "bin";
-          }
-          {
-            name = "XDG_CACHE_DIR";
-            eval = "$DEVSHELL_ROOT/$(echo .cache)";
-          }
-        ];
-      };
-    in
-    runTest "devshell-env-1" { } ''
-      unset XDG_DATA_DIRS
-
-      # Load the devshell
-      source ${shell}
-
-      # NIXPKGS_PATH is being set
-      assert "$NIXPKGS_PATH" == "${toString pkgs.path}"
-
-      assert "$XDG_DATA_DIRS" == "$DEVSHELL_DIR/share:/usr/local/share:/usr/share"
-
-      assert "$HTTP_PORT" == 8080
-
-      # PATH is prefixed with an expanded bin folder
-      [[ $PATH == $PWD/bin:* ]]
-
-      # Eval
-      assert "$XDG_CACHE_DIR" == "$PWD/.cache"
-    '';
 }

--- a/tests/env.nix
+++ b/tests/env.nix
@@ -1,0 +1,43 @@
+{ pkgs, devshell, runTest }:
+{
+  # Test the environment variables
+  env-1 =
+    let
+      shell = devshell.mkShell {
+        devshell.name = "devshell-env-1";
+        env = [
+          {
+            name = "HTTP_PORT";
+            value = 8080;
+          }
+          {
+            name = "PATH";
+            prefix = "bin";
+          }
+          {
+            name = "XDG_CACHE_DIR";
+            eval = "$DEVSHELL_ROOT/$(echo .cache)";
+          }
+        ];
+      };
+    in
+    runTest "devshell-env-1" { } ''
+      unset XDG_DATA_DIRS
+
+      # Load the devshell
+      source ${shell}
+
+      # NIXPKGS_PATH is being set
+      assert "$NIXPKGS_PATH" == "${toString pkgs.path}"
+
+      assert "$XDG_DATA_DIRS" == "$DEVSHELL_DIR/share:/usr/local/share:/usr/share"
+
+      assert "$HTTP_PORT" == 8080
+
+      # PATH is prefixed with an expanded bin folder
+      [[ $PATH == $PWD/bin:* ]]
+
+      # Eval
+      assert "$XDG_CACHE_DIR" == "$PWD/.cache"
+    '';
+}


### PR DESCRIPTION
Sorry! devshell is not stable yet.

[[devshell.env]] was really a mouthful so it got moved in place of
[env].

Instead of:

    [env]
    FOO = "bar"
    BAR = "baz"

Use:

    [[env]]
    name = "FOO"
    value = "bar"

    [[env]]
    name = "BAR"
    value = "baz"