### PR TITLE
modules: introduce extra modules

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,8 @@
 
 - [Intro](./intro.md)
 - [Getting started](./getting_started.md)
-- [devshell.toml](./devshell.toml.md)
 - [Continuous Integration setup](./ci.md)
+- [Extending devshell](./extending.md)
+- [devshell.toml schema](./modules_schema.md)
 - [TODO](./99_todo.md)
 

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   };
 
   buildPhase = ''
-    cp ${modules-docs.markdown} devshell.toml.md
+    cp ${modules-docs.markdown} modules_schema.md
     mdbook build
   '';
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,47 @@
+# Extending devshell
+
+When the base modules that are provided by devshell are not enough, it is
+possible to extend it.
+
+## Extra modules
+
+All the `devshell.toml` schema options that are prefixed with `extra.<name>`
+are only loaded on demand. This is done to keep devshell fast for users that
+don't need all the modules.
+
+In order to load an extra module, use the `<name>` in the import section. For
+example to make the `extra.locale` options available, import `locale`:
+
+`devshell.toml`:
+```toml
+imports = ["locale"]
+```
+
+Make sure to add this at the first statement in the file.
+
+Now that the module has been loaded, the `devshell.toml` understands the extra
+options:
+
+```toml
+imports = ["extra.locale"]
+
+[extra.locale]
+lang = "en_US.UTF-8"
+```
+
+## Building your own modules
+
+Building your own modules requires to understand the Nix language. If Nix
+this is too complicated, please reach out to the issue tracker and describe
+your use-case. We want to be able to support a wide variety of development
+scenario.
+
+In the same way as previously introduced, devshell will also load files that
+are relative to the `devshell.toml`. For example:
+
+```toml
+imports = ["mymodule.nix"]
+```
+
+Will load the `mymodule.nix` file in the project repository and extend the
+`devshell.toml` schema accordingly.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -20,6 +20,8 @@ in
 devshell.fromTOML ./devshell.toml
 ```
 
+> NOTE: it's probably a good idea to pin the dependency by replacing `master` with a git commit ID.
+
 Now you can enter the developer shell for the project:
 
 ```console
@@ -45,7 +47,33 @@ warning: you did not specify '--add-root'; the result might be removed by the ga
 [devshell]$
 ```
 
+## Adding environment variables
+
+Environment variables that are specific to the project can be added with the
+`[[env]]` declaration. Each environment variable is an entry in an array, and
+will be set in the order that they are declared.
+
+Eg:
+
+```toml
+[[env]]
+name = "GO111MODULE"
+value = "on"
+```
+
+There are different ways to set the environment variables. Look at the schema
+to find all the ways. But in short:
+* Use the `value` key to set a fixed env var.
+* Use the `eval` key to evaluate the value. This is useful when one env var
+  depends on the value of another.
+* Use the `prefix` key to prepend a path to an environment variable that uses
+  the path separator. Like `PATH`.
+
 ## Adding new commands
+
+Devshell also supports adding new commands to the environment. Those are
+displayed on devshell entry so that the user knows what commands are available
+to them.
 
 In order to bring in new dependencies, you can either add them to
 `devshell.packages` or to the `commands` list. Commands are also added to the
@@ -97,5 +125,7 @@ packages = [
 ]
 ```
 
-devshell is extensible in many different ways. The next chapter will show all
+devshell is extensible in many different ways. In the next chapters we will
+discuss the various ways in which it can be adapted to your project's needs.
+to find 
 of the configuration options available.

--- a/modules_extra/locale.nix
+++ b/modules_extra/locale.nix
@@ -1,0 +1,38 @@
+{ lib, pkgs, config, ... }:
+with lib;
+let
+  cfg = config.extra.locale;
+in
+{
+  options.extra.locale = {
+    lang = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Set the language of the project";
+      example = "en_GB.UTF-8";
+    };
+
+    package = mkOption {
+      type = types.package;
+      description = "Set the glibc locale package that will be used on Linux";
+      default = pkgs.glibcLocales;
+      defaultText = "pkgs.glibcLocales";
+    };
+  };
+  config.env =
+    lib.optional pkgs.stdenv.isLinux
+      {
+        name = "LOCALE_ARCHIVE";
+        value = "${cfg.package}/lib/locale/locale-archive";
+      }
+    ++ lib.optionals (cfg.lang != null) [
+      {
+        name = "LANG";
+        value = cfg.lang;
+      }
+      {
+        name = "LC_ALL";
+        value = cfg.lang;
+      }
+    ];
+}


### PR DESCRIPTION
Introduces extra modules that can be loaded on-demand. This is to
avoid long evaluation times as the list of modules grow.

Whenever a module is prefixed with `extra.` in the docs, it can be
loaded by putting `import = ["extra.<name>"]` at the top of the
devshell.toml.