### PR TITLE
language.c: bang into shape

### DIFF
--- a/extra/language/c.nix
+++ b/extra/language/c.nix
@@ -9,6 +9,24 @@ in
 with lib;
 {
   options.language.c = {
+    compiler = mkOption {
+      type = strOrPackage;
+      default = pkgs.clang;
+      defaultText = "pkgs.clang";
+      description = ''
+        Which C compiler to use.
+
+        For gcc, use pkgs.gcc-unwrapped.
+      '';
+    };
+
+    linker = mkOption {
+      type = strOrPackage;
+      default = pkgs.binutils;
+      defaultText = "pkgs.binutils";
+      description = "Which linker package to use";
+    };
+
     libraries = mkOption {
       type = types.listOf strOrPackage;
       default = [ ];
@@ -26,21 +44,11 @@ with lib;
       description = "C dependencies from nixpkgs";
     };
 
-    compiler = mkOption {
-      type = strOrPackage;
-      default = pkgs.clang;
-      defaultText = "pkgs.clang";
-      description = ''
-        Which C compiler to use.
-
-        For gcc, use pkgs.gcc-unwrapped.
-      '';
-    };
   };
 
   config = {
     devshell.packages =
-      [ cfg.compiler ]
+      [ cfg.compiler cfg.linker ]
       ++
       (lib.optionals hasLibraries (map lib.getLib cfg.libraries))
       ++


### PR DESCRIPTION
A few learning:

`ld` uses LIBRARY_PATH, not LD_LIBRARY_PATH to find object files. Link to the
libraries directly to minimize rebuilds.

`pkgs.gcc` doesn't expose the gcov binary. `pkgs.gcc` is heavily tweaked to
work with the nixpkgs stdenv so use `pkgs.gcc-unwrapped` instead.

Made `pkg-config` optional, it's not used all the time.