### PR TITLE
Fix writeDefaultShellScript to actually include default shebang

### DIFF
--- a/nix/writeDefaultShellScript.nix
+++ b/nix/writeDefaultShellScript.nix
@@ -13,12 +13,13 @@
 }:
 let
   script =
-    if lib.hasPrefix "#!" then text
+    if lib.hasPrefix "#!" text then text
     else "${defaultShebang}\n${text}";
 in
 writeTextFile (
   {
-    inherit name text;
+    inherit name;
+    text = script;
     executable = true;
   }
   // (lib.optionalAttrs (checkPhase != null) { inherit checkPhase; })


### PR DESCRIPTION
In [`writeDefaultShellScript.nix`](https://github.com/numtide/devshell/blob/ff6cffba08600f5b7b43f398fcb58bef023bc4c4/nix/writeDefaultShellScript.nix#L15), the `script` variable provides a default shebang if none is given in the passed `text` parameter, but `script` never actually gets passed to `writeTextFile` and the (unpatched) `text` is passed instead! Fixed that to pass `script`.

Additionally, fixed the call to `lib.hasPrefix`.