### PR TITLE
modules: add importTOML as a specialArg

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -13,6 +13,7 @@ let
     modules = [ configuration ] ++ devenvModules;
     specialArgs = {
       modulesPath = builtins.toString ./.;
+      inherit (pkgs.devshell) importTOML;
     } // extraSpecialArgs;
   };
 in


### PR DESCRIPTION
this would allow modules to import toml files in an `imports` line

```
{ importTOML, ... }: {
  imports = [ (importTOML ./devshell.toml) ];
}
```