### PR TITLE
all-in-one: merge entrypoint into the devshell dir

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -14,4 +14,4 @@ nix-build shell.nix --out-link "$out_link"
 
 # Load the devshell
 # shellcheck disable=SC1090
-source "$out_link"
+source "$out_link/env.bash"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,7 +18,8 @@ jobs:
         with:
           name: numtide
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - run: $(nix-build shell.nix) --pure /usr/bin/env HOME=$HOME bash -c "cd devshell && golangci-lint run"
+      - run: |
+          $(./shell.nix)/entrypoint --pure /usr/bin/env HOME=$HOME bash -c "cd devshell && golangci-lint run"
       - run: nix-shell --run "echo OK"
       - run: nix-build
   flakes:

--- a/nix/mkNakedShell.nix
+++ b/nix/mkNakedShell.nix
@@ -22,8 +22,9 @@ let
   };
 in
 { name
-, # A path to a script that will be loaded by the shell
-  script
+, # A path to a buildEnv that will be loaded by the shell.
+  # We assume that the buildEnv contains an ./env.bash script.
+  profile
 , meta ? { }
 , passthru ? { }
 }:
@@ -34,7 +35,7 @@ in
   builder = bashPath;
 
   # Bring in the dependencies on `nix-build`
-  args = [ "-ec" "${coreutils}/bin/ln -s ${script} $out; exit 0" ];
+  args = [ "-ec" "${coreutils}/bin/ln -s ${profile} $out; exit 0" ];
 
   # $stdenv/setup is loaded by nix-shell during startup.
   # https://github.com/nixos/nix/blob/377345e26f1ac4bbc87bb21debcc52a1d03230aa/src/nix-build/nix-build.cc#L429-L432
@@ -55,7 +56,7 @@ in
       export SHELL=${bashPath}
     fi
 
-    # Load the script environment
-    source "${script}"
+    # Load the environment
+    source "${profile}/env.bash"
   '';
 }) // { inherit meta passthru; } // passthru

--- a/tests/core/commands.nix
+++ b/tests/core/commands.nix
@@ -31,7 +31,7 @@
     in
     runTest "devshell-1" { } ''
       # Load the devshell
-      source ${shell}
+      source ${shell}/env.bash
 
       menu
 

--- a/tests/core/devshell.nix
+++ b/tests/core/devshell.nix
@@ -10,7 +10,7 @@
     in
     runTest "devshell-1" { } ''
       # Load the devshell
-      source ${shell}
+      source ${shell}/env.bash
 
       # Sets an environment variable that points to the buildEnv
       assert -n "$DEVSHELL_DIR"

--- a/tests/core/env.nix
+++ b/tests/core/env.nix
@@ -25,7 +25,7 @@
       unset XDG_DATA_DIRS
 
       # Load the devshell
-      source ${shell}
+      source ${shell}/env.bash
 
       # NIXPKGS_PATH is being set
       assert "$NIXPKGS_PATH" == "${toString pkgs.path}"

--- a/tests/extra/git.hooks.nix
+++ b/tests/extra/git.hooks.nix
@@ -26,7 +26,7 @@
       assert_fail -L .git/hooks/pre-commit
 
       # Load the devshell
-      source ${shell1}
+      source ${shell1}/env.bash
 
       # The hook has been install
       assert -L .git/hooks/pre-commit
@@ -35,7 +35,7 @@
       assert "$(.git/hooks/pre-commit)" == "PRE-COMMIT"
 
       # Load the new config
-      source ${shell2}
+      source ${shell2}/env.bash
 
       # The hook should have been uninstalled
       assert_fail -L .git/hooks/pre-commit

--- a/tests/extra/language.c.nix
+++ b/tests/extra/language.c.nix
@@ -10,7 +10,7 @@
     in
     runTest "language-c-1" { } ''
       # Load the devshell
-      source ${shell}
+      source ${shell}/env.bash
 
 
       # Has a C compiler

--- a/tests/extra/language.rust.nix
+++ b/tests/extra/language.rust.nix
@@ -10,7 +10,7 @@
     in
     runTest "simple" { } ''
       # Load the devshell
-      source ${shell}
+      source ${shell}/env.bash
 
       # Has a rust compiler
       type -p rustc

--- a/tests/extra/locale.nix
+++ b/tests/extra/locale.nix
@@ -13,7 +13,7 @@
       assert -z "$LOCALE_ARCHIVE"
 
       # Load the devshell
-      source ${shell}
+      source ${shell}/env.bash
 
       # Sets LOCALE_ARCHIVE
       if [[ $OSTYPE == linux-gnu ]]; then


### PR DESCRIPTION
Split the entrypoint and env.bash. This makes it easier to expose the
buildEnv.