### PR TITLE
fix: fence against PATH pollution through etc/profiles.d

### DIFF
--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -224,11 +224,19 @@ in
 
     startup = {
       load_profiles = noDepEntry ''
+        # PATH is devshell's exorbitant privilige:
+        # fence against its pollution
+        _PATH=''${PATH}
+
         # Load installed profiles
         for file in "$DEVSHELL_DIR/etc/profile.d/"*.sh; do
           # If that folder doesn't exist, bash loves to return the whole glob
           [[ -f "$file" ]] && source "$file"
         done
+
+        # Exert exorbitant privilige and leave no trace
+        export PATH=''${_PATH}
+        unset _PATH
       '';
 
       motd = noDepEntry ''


### PR DESCRIPTION
fixes: #26

With this fix applied, `PATH` looks good now:

`PATH=/nix/store/[...]-devshell-dir/bin:/nix/store/[...]-bash-interactive-4.4-p23/bin:/path-not-set:[...]`
