### PR TITLE
Specify `extra` commands to add menu entries for additional package binaries of a command ( #131 )

### DIFF
--- a/devshell.toml
+++ b/devshell.toml
@@ -45,3 +45,13 @@ category = "utilites"
 help = "golang linter"
 package = "golangci-lint"
 category = "linters"
+
+[[commands]]
+package = "go"
+
+# Declares an extra command for the go command since gofmt is included in the
+# go package.
+[[commands.extra]]
+name = "gofmt"
+help = "Formats Go programs"
+category = "formatters"


### PR DESCRIPTION
The context for this PR is described in #131

I added an example of the `commands.extra` options in the root `devshell.toml`. I'm not sure if this is desirable, I can revert that commit if needed. I didn't add documentation or tests, but I can if that would be welcome.

With this added bit in `devshell.toml`:

```toml
[[commands]]
package = "go"

# Declares an extra command for the go command since gofmt is included in the
# go package.
[[commands.extra]]
name = "gofmt"
help = "Formats Go programs"
category = "formatters"
```

The motd now displays:

```
🔨 Welcome to devshell

[formatters]

  gofmt         - Formats Go programs
  nixpkgs-fmt   - Nix code formatter for nixpkgs

[general commands]

  go            - The Go Programming language
  hello         - prints hello
  menu          - prints this menu

[linters]

  golangci-lint - golang linter

[utilites]

  hub           - github utility

```

Note the go package is already imported by `language.go`, so the extra config in `devshell.toml` is only useful to display `go` and `gofmt` in the help menu.

Before these changes, adding a command for `gofmt` wouldn't be possible without creating naming it differently than `gofmt`.