### PR TITLE
imp: keep access `extraModulesPath` encapsulated in the module system

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -13,6 +13,7 @@ let
     modules = [ configuration ] ++ devenvModules;
     specialArgs = {
       modulesPath = builtins.toString ./.;
+      extraModulesPath = builtins.toString ../extra;
     } // extraSpecialArgs;
   };
 in


### PR DESCRIPTION
fix #134
