### PR TITLE
introduce service.postgres

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,7 +19,8 @@ jobs:
           name: numtide
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: |
-          $(./shell.nix)/entrypoint --pure /usr/bin/env HOME=$HOME bash -c "cd devshell && golangci-lint run"
+          export PRJ_ROOT=$PWD
+          $(./shell.nix)/entrypoint --pure bash -c "cd devshell && golangci-lint run"
       - run: nix-shell --run "echo OK"
       - run: nix-build
   flakes:

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ direnv: export +AR +AS +CC +CONFIG_SHELL +CXX +HOST_PATH +IN_NIX_SHELL +LD +NIX_
 ```
 to:
 ```
-direnv: export +DEVSHELL_DIR +DEVSHELL_ROOT +IN_NIX_SHELL +NIXPKGS_PATH ~PATH
+direnv: export +DEVSHELL_DIR +PRJ_ROOT +IN_NIX_SHELL +NIXPKGS_PATH ~PATH
 ```
 
 There are new environment variables useful to support the day-to-day
 activities:
 * `DEVSHELL_DIR`: contains all the programs.
-* `DEVSHELL_ROOT`: points to the project root.
+* `PRJ_ROOT`: points to the project root.
 * `NIXPKGS_PATH`: path to `nixpkgs` source.
 
 ### Common utilities

--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ direnv: export +AR +AS +CC +CONFIG_SHELL +CXX +HOST_PATH +IN_NIX_SHELL +LD +NIX_
 ```
 to:
 ```
-direnv: export +DEVSHELL_DIR +PRJ_ROOT +IN_NIX_SHELL +NIXPKGS_PATH ~PATH
+direnv: export +DEVSHELL_DIR +PRJ_DATA_DIR +PRJ_ROOT +IN_NIX_SHELL +NIXPKGS_PATH ~PATH
 ```
 
 There are new environment variables useful to support the day-to-day
 activities:
 * `DEVSHELL_DIR`: contains all the programs.
 * `PRJ_ROOT`: points to the project root.
+* `PRJ_DATA_DIR`: points to `$PRJ_ROOT/.data` by default. Is used to store runtime data.
 * `NIXPKGS_PATH`: path to `nixpkgs` source.
 
 ### Common utilities

--- a/extra/service/postgres.nix
+++ b/extra/service/postgres.nix
@@ -1,0 +1,45 @@
+# This module automatically configures postgres when the user enters the
+# devshell.
+#
+# To start the server, invoke `postgres` in one devshell. Then start a second
+# devshell to run the clients.
+{ lib, pkgs, config, ... }:
+with lib;
+let
+  cfg = config.service.postgres;
+in
+{
+  options.service.postgres = {
+    package = mkOption {
+      type = types.package;
+      description = "Which version of postgres to use";
+      default = pkgs.postgresql;
+      defaultText = "pkgs.postgresl";
+    };
+  };
+  config = {
+    packages = [ cfg.package ];
+
+    env = [
+      {
+        name = "PGDATA";
+        eval = "$PRJ_DATA_DIR/postgres";
+      }
+      {
+        name = "PGHOST";
+        eval = "$PGDATA";
+      }
+    ];
+
+    devshell.startup.setup-postgres.text = ''
+      if [[ ! -d "$PGDATA" ]]; then
+      initdb
+      cat >> "$PGDATA/postgresql.conf" <<EOF
+        listen_addresses = '''
+        unix_socket_directories = '$PGHOST'
+      EOF
+      echo "CREATE DATABASE ''${USER:-$(id -nu)};" | postgres --single -E postgres
+      fi
+    '';
+  };
+}

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -58,8 +58,13 @@ let
 
   # Write a bash profile to load
   envBash = pkgs.writeText "devshell-env.bash" ''
-    # It assums that the shell is always loaded from the root of the project.
-    export PRJ_ROOT=''${PRJ_ROOT:-$PWD}
+    if [[ -n ''${IN_NIX_SHELL:-} || ''${DIRENV_IN_ENVRC:-} = 1 ]]; then
+      # We know that PWD is always the current directory in these contexts
+      export PRJ_ROOT=$PWD
+    elif [[ -z ''${PRJ_ROOT:-} ]]; then
+      echo "ERROR: please set the PRJ_ROOT env var to point to the project root" >&2
+      return 1
+    fi
 
     # Expose the folder that contains the assembled environment.
     export DEVSHELL_DIR=@DEVSHELL_DIR@

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -121,7 +121,7 @@ let
     elif [[ $1 == "--pure" ]]; then
       # re-execute the script in a clean environment
       shift
-      exec -c "$0" "$@"
+      exec /usr/bin/env -i -- "HOME=$HOME" "PRJ_ROOT=$PRJ_ROOT" "$0" "$@"
     else
       # Start a script
       source "$DEVSHELL_DIR/env.bash"

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -59,7 +59,7 @@ let
   # Write a bash profile to load
   envBash = pkgs.writeText "devshell-env.bash" ''
     # It assums that the shell is always loaded from the root of the project.
-    export DEVSHELL_ROOT=''${DEVSHELL_ROOT:-$PWD}
+    export PRJ_ROOT=''${PRJ_ROOT:-$PWD}
 
     # Expose the folder that contains the assembled environment.
     export DEVSHELL_DIR=@DEVSHELL_DIR@
@@ -260,17 +260,17 @@ in
 
     interactive = {
       PS1_util = noDepEntry ''
-        if [[ -n "''${DEVSHELL_ROOT:-}" ]]; then
-          # Print the path relative to $DEVSHELL_ROOT
+        if [[ -n "''${PRJ_ROOT:-}" ]]; then
+          # Print the path relative to $PRJ_ROOT
           rel_root() {
             local path
-            path=$(${pkgs.coreutils}/bin/realpath --relative-to "$DEVSHELL_ROOT" "$PWD")
+            path=$(${pkgs.coreutils}/bin/realpath --relative-to "$PRJ_ROOT" "$PWD")
             if [[ $path != . ]]; then
               echo " $path "
             fi
           }
         else
-          # If DEVSHELL_ROOT is unset, print only the current directory name
+          # If PRJ_ROOT is unset, print only the current directory name
           rel_root() {
             echo " \W "
           }

--- a/modules/env.nix
+++ b/modules/env.nix
@@ -72,7 +72,7 @@ in
         }
         {
           name = "XDG_CACHE_DIR";
-          eval = "$DEVSHELL_ROOT/.cache";
+          eval = "$PRJ_ROOT/.cache";
         }
       ]
     '';

--- a/modules/env.nix
+++ b/modules/env.nix
@@ -92,6 +92,12 @@ in
         name = "XDG_DATA_DIRS";
         eval = ''$DEVSHELL_DIR/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}'';
       }
+
+      # A per-project data directory for runtime information.
+      {
+        name = "PRJ_DATA_DIR";
+        eval = "\${PRJ_DATA_DIR:-$PRJ_ROOT/.data}";
+      }
     ];
 
     devshell.startup_env = concatStringsSep "\n" (map envToBash config.env);

--- a/tests/core/devshell.nix
+++ b/tests/core/devshell.nix
@@ -15,8 +15,8 @@
       # Sets an environment variable that points to the buildEnv
       assert -n "$DEVSHELL_DIR"
 
-      # Points DEVSHELL_ROOT to the project root
-      assert "$PWD" == "$DEVSHELL_ROOT"
+      # Points PRJ_ROOT to the project root
+      assert "$PWD" == "$PRJ_ROOT"
 
       # Adds packages to the PATH
       type -p git

--- a/tests/core/env.nix
+++ b/tests/core/env.nix
@@ -16,7 +16,7 @@
           }
           {
             name = "XDG_CACHE_DIR";
-            eval = "$DEVSHELL_ROOT/$(echo .cache)";
+            eval = "$PRJ_ROOT/$(echo .cache)";
           }
         ];
       };

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,6 +7,9 @@ let
     pkgs.runCommand name attrs ''
       source ${./assert.sh}
 
+      # Needed by devshell
+      export PRJ_ROOT=$PWD
+
       ${script}
 
       touch $out

--- a/tests/extra/service.postgres.nix
+++ b/tests/extra/service.postgres.nix
@@ -1,0 +1,35 @@
+{ pkgs, devshell, runTest }:
+{
+  # Basic test
+  simple =
+    let
+      shell = devshell.mkShell {
+        imports = [ ../../extra/service/postgres.nix ];
+        devshell.name = "service-postgres-example";
+      };
+    in
+    runTest "simple" { } ''
+      # Load the devshell
+      source ${shell}/env.bash
+
+      # Has postgres
+      type -p postgres
+
+      # Start postgres in the background
+      pg_ctl start
+      trap "pg_ctl stop" EXIT
+
+      # Test that the DB is up and running
+      i=0
+      while ! pg_isready; do
+        if [[ $i -gt 10 ]]; then
+          echo "could not connect to postgres"
+          exit 1
+        fi
+        ((i++))
+        sleep 0.2
+        echo "x"
+      done
+      echo OK
+    '';
+}


### PR DESCRIPTION
This is not a full service like nixos or home-manage services. But it puts in
place the base to be able to start the service.

Usage (devshell.toml):

```toml
imports = [ "service.postgres" ]

[service.postgres]
package = "postgres_12"
```

After entering the devshell, run `pg_ctrl start` to start the server.