### PR TITLE
Allow full 256 color ansi palette + italic, underline in toml and nix.

### DIFF
--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -193,9 +193,9 @@ in
         {202}🔨 Welcome to ${cfg.name}{reset}
         $(type -p menu &>/dev/null && menu)
       '';
-      apply = builtins.replaceStrings
+      apply = replaceStrings
         (map (key: "{${key}}") (attrNames ansi))
-        (map (esc: "${esc}") (attrValues ansi));
+        (attrValues ansi);
       description = ''
         Message Of The Day.
 

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -190,9 +190,12 @@ in
     motd = mkOption {
       type = types.str;
       default = ''
-        ${ansi.orange}🔨 Welcome to ${cfg.name}${ansi.reset}
+        {202}🔨 Welcome to ${cfg.name}{reset}
         $(type -p menu &>/dev/null && menu)
       '';
+      apply = builtins.replaceStrings
+        (map (key: "{${key}}") (attrNames ansi))
+        (map (esc: "${esc}") (attrValues ansi));
       description = ''
         Message Of The Day.
 

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -201,6 +201,8 @@ in
 
         This is the welcome message that is being printed when the user opens
         the shell.
+
+        You may use any valid ansi color from the 8-bit ansi color table. For example, to use a green color you would use something like {106}. You may also use {bold}, {italic}, {underline}. Use {reset} to turn off all attributes.
       '';
     };
 

--- a/nix/ansi.nix
+++ b/nix/ansi.nix
@@ -1,10 +1,13 @@
 # Ansi escape codes
-rec {
+let
   # Nix strings only support \t, \r and \n as escape codes, so actually store
   # the literal escape "ESC" code.
+  inherit (builtins) foldl' genList;
   esc = "";
-
-  orange = "${esc}[38;5;202m";
+in
+{
   reset = "${esc}[0m";
   bold = "${esc}[1m";
-}
+  italic = "${esc}[3m";
+  underline = "${esc}[4m";
+} // (foldl' (x: y: x // { "${toString y}" = "${esc}[38;5;${toString y}m"; }) {} (genList (x: x) 256))

--- a/nix/ansi.nix
+++ b/nix/ansi.nix
@@ -10,4 +10,4 @@ in
   bold = "${esc}[1m";
   italic = "${esc}[3m";
   underline = "${esc}[4m";
-} // (foldl' (x: y: x // { "${toString y}" = "${esc}[38;5;${toString y}m"; }) {} (genList (x: x) 256))
+} // (foldl' (x: y: x // { "${toString y}" = "${esc}[38;5;${toString y}m"; }) { } (genList (x: x) 256))

--- a/nix/writeDefaultShellScript.nix
+++ b/nix/writeDefaultShellScript.nix
@@ -1,10 +1,10 @@
 { lib, writeTextFile, bash }:
 
 /*
- * Similar to writeShellScript, except that a default shebang can be provided
- *
- * Either the script already has a shebang, or one will be provided for it.
- */
+  Similar to writeShellScript, except that a default shebang can be provided
+
+  Either the script already has a shebang, or one will be provided for it.
+*/
 { name
 , text
 , defaultShebang ? "#!${bash}/bin/bash\nset -euo pipefail\n"


### PR DESCRIPTION
I wanted to use the full ansi color palette plus italic and underline in motd, plus I wanted to use it from TOML. This enables such usage through replacement strings. In the case of colors the replacement strings are just "{<color_number_here>}" while for bold, reset, underline and italic they are "{bold}", "{reset}", "{underline}" and "{italic}" respectively.

A toml example would be:

```toml
[devshell]
name = "ansi"

motd = """

{bold}{102}ANSI{reset}{102} - who doesn't like colors?{reset}

"""
```