### PR TITLE
BREAKING: don't load etc/profile.d/*.sh by default

### DIFF
--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -201,6 +201,8 @@ in
       '';
     };
 
+    load_profiles = mkEnableOption "load etc/profiles.d/*.sh in the shell";
+
     name = mkOption {
       type = types.str;
       default = "devshell";
@@ -231,14 +233,6 @@ in
     package = devshell_dir;
 
     startup = {
-      load_profiles = noDepEntry ''
-        # Load installed profiles
-        for file in "$DEVSHELL_DIR/etc/profile.d/"*.sh; do
-          # If that folder doesn't exist, bash loves to return the whole glob
-          [[ -f "$file" ]] && source "$file"
-        done
-      '';
-
       motd = noDepEntry ''
         __devshell-motd() {
           cat <<DEVSHELL_PROMPT
@@ -261,7 +255,15 @@ in
           PROMPT_COMMAND=__devshell-prompt''${PROMPT_COMMAND+;$PROMPT_COMMAND}
         fi
       '';
-    };
+    } // (optionalAttrs cfg.load_profiles {
+      load_profiles = lib.noDepEntry ''
+        # Load installed profiles
+        for file in "$DEVSHELL_DIR/etc/profile.d/"*.sh; do
+          # If that folder doesn't exist, bash loves to return the whole glob
+          [[ -f "$file" ]] && source "$file"
+        done
+      '';
+    });
 
     interactive = {
       PS1_util = noDepEntry ''

--- a/tests/core/devshell.nix
+++ b/tests/core/devshell.nix
@@ -21,4 +21,29 @@
       # Adds packages to the PATH
       type -p git
     '';
+
+  # Only load profiles
+  devshell-load-profiles-1 =
+    let
+      fakeProfile = pkgs.writeTextFile {
+        name = "fake_profile.sh";
+        destination = "/etc/profile.d/fake_profile.sh";
+        text = ''
+          export FAKE_PROFILE=1
+        '';
+      };
+
+      shell = devshell.mkShell {
+        devshell.name = "devshell-1";
+        devshell.load_profiles = true;
+        devshell.packages = [ fakeProfile ];
+      };
+    in
+    runTest "devshell-load-profiles-1" { } ''
+      # Load the devshell
+      source ${shell}/env.bash
+
+      # Check that the profile got loaded
+      assert "$FAKE_PROFILE" == "1"
+    '';
 }


### PR DESCRIPTION
Fixes #26
Fixes #123

To get the old behaviour back, set `devshell.load_profiles` to
`true`.

Future improvements might be to explicitly list which profiles should be
loaded.