### PR TITLE
fix(hooks): do not install hooks if no git folder

### DIFF
--- a/extra/git/hooks.nix
+++ b/extra/git/hooks.nix
@@ -74,7 +74,11 @@ let
     export PATH=${pkgs.coreutils}/bin:$PATH
 
     # Find the git dir
-    git_work_tree=$(${pkgs.gitMinimal}/bin/git rev-parse --show-toplevel)
+    git_work_tree=$(${pkgs.gitMinimal}/bin/git rev-parse --show-toplevel || true)
+    if [[ $git_work_tree == "" ]]; then
+      log "skipping as we can't find any .git folder, we are probably not in a git repository" >&2
+      exit
+    fi
     git_dir=$(${pkgs.gitMinimal}/bin/git rev-parse --absolute-git-dir)
     source_hook_dir=${hooksDir}/bin
     target_hook_dir=$git_dir/hooks


### PR DESCRIPTION
When running devshell in a folder which is not a git repository, we face this error:

```
++ git rev-parse --show-toplevel
fatal: not a git repository (or any parent up to mount point /)
```

Solution is to abort git hook install if we are not in a git repository.