### PR TITLE
overlay.nix: fix

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,5 +1,5 @@
 # Import this overlay in your project to add devshell and mkDevShell
 final: prev:
 {
-  devshell = import ./. { pkgs = final; };
+  devshell = import ./. { nixpkgs = final; };
 }


### PR DESCRIPTION
As of 2fb6740996ccf01212f2efdf1dc2a9241a6acf57, `default.nix` changed its signature and the overlay was not updated for compatibility.

```
error: anonymous function at /nix/store/d4m6hpyv09n5k4x65mcxpsdxrdy0crfp-source/default.nix:1:1 called with unexpected argument 'pkgs'

       at /nix/store/d4m6hpyv09n5k4x65mcxpsdxrdy0crfp-source/overlay.nix:4:14:

            3| {
            4|   devshell = import ./. { pkgs = final; };
             |              ^
            5| }