### PR TITLE
imp: sanitize devshell (derivation) name

### DIFF
--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -297,7 +297,7 @@ in
 
     # Use a naked derivation to limit the amount of noise passed to nix-shell.
     shell = mkNakedShell {
-      name = cfg.name;
+      name = strings.sanitizeDerivationName cfg.name;
       profile = cfg.package;
       passthru = {
         inherit config;


### PR DESCRIPTION
- allow a little more creativity in devshell naming:
  - `numtide/devshell` -- `/` would have been illegal
  - `Bitte Cells` -- ` ` would have been illegal
