### PR TITLE
env: allow packages as values

### DIFF
--- a/modules/env.nix
+++ b/modules/env.nix
@@ -8,7 +8,7 @@ let
     };
 
     value = mkOption {
-      type = with types; nullOr (oneOf [ str int bool ]);
+      type = with types; nullOr (oneOf [ str int bool package ]);
       default = null;
       description = "Shell-escaped value to set";
     };


### PR DESCRIPTION
This makes it easier to point an env var to a derivation path (eg: a
path to a config file that was generated with `nixpkgs.writeText`).