### PR TITLE
allow to disable the MOTD with an env var

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,5 +5,6 @@
 - [Continuous Integration setup](./ci.md)
 - [Extending devshell](./extending.md)
 - [devshell.toml schema](./modules_schema.md)
+- [env vars](./env.md)
 - [TODO](./99_todo.md)
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,9 @@
+# Env vars
+
+This section describes a few environment variables that can influence the
+behaviour of devshell.
+
+## `DEVSHELL_NO_MOTD=1`
+
+When that variable is set, devshell will not display the menu that is executed
+on entrypoint.

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -245,8 +245,11 @@ in
         DEVSHELL_PROMPT
         }
 
-        # Print the motd in direnv
-        if [[ ''${DIRENV_IN_ENVRC:-} = 1 ]]; then
+        if [[ ''${DEVSHELL_NO_MOTD:-} = 1 ]]; then
+          # Skip if that env var is set
+          :
+        elif [[ ''${DIRENV_IN_ENVRC:-} = 1 ]]; then
+          # Print the motd in direnv
           __devshell-motd
         else
           # Print information if the prompt is displayed. We have to make


### PR DESCRIPTION
In some environments like CI, it doesn't make sense to show the menu
over and over again.

To avoid that noise, set DEVSHELL_NO_MOTD=1.