### PR TITLE
rust: add option for environment variables

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -28,6 +28,12 @@ imports = ["locale"]
 lang = "en_US.UTF-8"
 ```
 
+From a nix flake you would import it like
+
+```nix
+imports = ["${devshell}/extra/locale.nix"];
+```
+
 ## Building your own modules
 
 Building your own modules requires to understand the Nix language. If

--- a/extra/language/rust.nix
+++ b/extra/language/rust.nix
@@ -24,7 +24,7 @@ with lib;
     };
     enableDefaultToolchain = mkOption {
       type = types.bool;
-      default = true;      
+      default = true;
       defaultText = "true";
       description = "Enable the default rust toolchain coming from nixpkgs";
     };

--- a/extra/language/rust.nix
+++ b/extra/language/rust.nix
@@ -31,7 +31,7 @@ with lib;
   };
 
   config = {
-    devshell.packages = if cfg.enableDefaultToochain then (map (tool: cfg.packageSet.${tool}) cfg.tools) else [];
+    devshell.packages = if cfg.enableDefaultToolchain then (map (tool: cfg.packageSet.${tool}) cfg.tools) else [ ];
     env = [
       {
         # On darwin for example enables finding of libiconv

--- a/extra/language/rust.nix
+++ b/extra/language/rust.nix
@@ -22,10 +22,16 @@ with lib;
       ];
       description = "Which rust tools to pull from the platform package set";
     };
+    enableDefaultToolchain = mkOption {
+      type = types.bool;
+      default = true;      
+      defaultText = "true";
+      description = "Enable the default rust toolchain coming from nixpkgs";
+    };
   };
 
   config = {
-    devshell.packages = map (tool: cfg.packageSet.${tool}) cfg.tools;
+    devshell.packages = if cfg.enableDefaultToochain then (map (tool: cfg.packageSet.${tool}) cfg.tools) else [];
     env = [
       {
         # On darwin for example enables finding of libiconv


### PR DESCRIPTION
I've put the rust environment variables behind a flag, just in case some people might not want it.

I've removed the RUST_SRC_PKGS as I don't think anyone would be using the rust coming from nixpkgs as it is consistently 1 or 2 versions behind stable. Most people using rust would be using one of the multiple overlays.

I'll post once more when I have tested.