### PR TITLE
imp: satisfy a top level untyped output scheme

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,16 @@
           nixpkgs = inputs.nixpkgs.legacyPackages.${system};
         };
       in
-      {
+      { inherit (pkgs)
+          cli
+          eval
+          extraModulesDir
+          mkShell
+          mkNakedShell
+          fromTOML
+          importTOML
+          ;
+      } // {
         defaultPackage = pkgs.cli;
         legacyPackages = pkgs;
         devShell = pkgs.fromTOML ./devshell.toml;


### PR DESCRIPTION
when `deSystemized` allows for immediate usage of devshell:

 - `devshell.mkShell` instead of going via the outside of a nixpkgs world
   completely confusing and non-sensical `legacyPackages`.

 - However, ideally, the system scope would be the first argument.

 - `deSystemize` for "super simple flake" experience: https://github.com/divnix/std/blob/main/src/de-systemize.nix
