### PR TITLE
BREAKING: extra/services/postgres: setup DB on demand

### DIFF
--- a/tests/extra/services.postgres.nix
+++ b/tests/extra/services.postgres.nix
@@ -15,6 +15,12 @@
       # Has postgres
       type -p postgres
 
+      # Has a setup script
+      setup-postgres
+
+      # Second call is idempotent and should succeed as well
+      setup-postgres
+
       # Start postgres in the background
       pg_ctl start
       trap "pg_ctl stop" EXIT


### PR DESCRIPTION
Calling initdb is pretty heavy and might not be needed by the user.
Maybe they are on another part of the monorepo. Or they are switching
between branches and don't care of using the DB in between. The point is
that we want to make this more lazy.

Introduce `start-postgres`, a script that setups the database before
starting postgres. Call that instead of postgres directly when stating
the database.

To restore the old behaviour, set

    services.postgres.setupPostgresOnStartup = true;