### PR TITLE
modules: introduce userhosts

### DIFF
--- a/extra/services/userhosts.nix
+++ b/extra/services/userhosts.nix
@@ -40,16 +40,19 @@ in
     };
   };
 
-  config = mkIf (cfg.hosts != {}) {
-    env = [
-      {
-        name = "HOSTS_FILE";
-        value = "${hostsFile}";
-      }
-      {
-        name = "LD_PRELOAD";
-        prefix = "${cfg.package}/lib/libuserhosts.so";
-      }
-    ];
-  };
+  config = mkIf (cfg.hosts != {}) (
+    assert assertMsg pkgs.stdenv.isLinux "services.usershosts is only supported on Linux";
+    {
+      env = [
+        {
+          name = "HOSTS_FILE";
+          value = "${hostsFile}";
+        }
+        {
+          name = "LD_PRELOAD";
+          prefix = "${cfg.package}/lib/libuserhosts.so";
+        }
+      ];
+    }
+  );
 }

--- a/extra/services/userhosts.nix
+++ b/extra/services/userhosts.nix
@@ -1,0 +1,40 @@
+{ pkgs, config, lib, ... }:
+with lib;
+let
+  cfg = config.services.userhosts;
+  hostsFile = pkgs.writeTextFile {
+    name = "hosts";
+    text =
+      let
+        lines = lib.mapAttrsToList
+          (ip: hostnames: "${ip} ${builtins.concatStringsSep " " hostnames}")
+          cfg.hosts;
+      in
+      "${builtins.concatStringsSep "\n" lines}\n";
+  };
+in
+{
+  options.services.userhosts = {
+    package = mkOption {
+      type = types.package;
+      default = pkgs.userhosts;
+    };
+    hosts = mkOption {
+      type = types.attrsOf (types.listOf types.string);
+      default = {};
+    };
+  };
+
+  config = mkIf (cfg.hosts != {}) {
+    env = [
+      {
+        name = "HOSTS_FILE";
+        value = "${hostsFile}";
+      }
+      {
+        name = "LD_PRELOAD";
+        prefix = "${cfg.package}/lib/libuserhosts.so";
+      }
+    ];
+  };
+}

--- a/extra/services/userhosts.nix
+++ b/extra/services/userhosts.nix
@@ -41,7 +41,9 @@ in
   };
 
   config = mkIf (cfg.hosts != {}) (
-    assert assertMsg pkgs.stdenv.isLinux "services.usershosts is only supported on Linux";
+    if !pkgs.stdenv.isLinux then
+      builtins.trace "warning: services.usershosts is only supported on Linux" {}
+    else
     {
       env = [
         {

--- a/extra/services/userhosts.nix
+++ b/extra/services/userhosts.nix
@@ -18,10 +18,25 @@ in
     package = mkOption {
       type = types.package;
       default = pkgs.userhosts;
+      description = ''
+        The package containing the LD_PRELOAD library libuserhosts.so.
+      '';
     };
     hosts = mkOption {
       type = types.attrsOf (types.listOf types.string);
       default = {};
+      description = ''
+        The host entries to use for userhosts.
+        The top-level entries are the addresses where hostnames are resolved to.
+        For each address you can supply a list of hostnames.
+        This structure represents the structure you'd see in /etc/hosts.
+
+        Note that, unlike /etc/hosts, you can also use names to resolve to as well.
+      '';
+      example = {
+        "127.0.0.1" = [ "example.org" ];
+        "myhost.local" = [ "mydomain.test" ];
+      };
     };
   };
 

--- a/tests/extra/services.userhosts.nix
+++ b/tests/extra/services.userhosts.nix
@@ -1,4 +1,7 @@
 { pkgs, devshell, runTest }:
+if !pkgs.stdenv.isLinux then
+  {}
+else
 {
   # Basic test
   simple =

--- a/tests/extra/services.userhosts.nix
+++ b/tests/extra/services.userhosts.nix
@@ -1,0 +1,27 @@
+{ pkgs, devshell, runTest }:
+{
+  # Basic test
+  simple =
+    let
+      shell = devshell.mkShell {
+        imports = [ ../../extra/services/userhosts.nix ];
+        packages = [
+          pkgs.netcat
+        ];
+        services.userhosts.hosts = {
+          "127.0.0.1" = [ "example.org" ];
+        };
+        devshell.name = "services-userhosts-simple";
+      };
+    in
+    runTest "simple" { } ''
+      # Load the devshell
+      source ${shell}/env.bash
+
+      nc -l 127.0.0.1 8080 &
+      LISTENER_PID=$!
+      trap "kill $LISTENER_PID 2>/dev/null || true" EXIT
+      sleep 0.1
+      nc -zv example.org 8080
+    '';
+}


### PR DESCRIPTION
The userhosts module allows changing DNS lookups within the shell. Where usually you'd change /etc/hosts, it is now possible to change these entries within the shell without root.

This uses LD_PRELOAD to let ld.so load the libuserhosts.so library and the HOSTS_FILE is set to a Nix-generated hosts file containing the hosts entries from the devshell configuration.

This PR is similar to https://github.com/numtide/devshell/pull/75, but is based on `userhosts` instead of `hostctl`.

Example:

```nix
pkgs.mkShell {
  imports = [
    ./extra/services/userhosts.nix
  ];

  services.userhosts.hosts = {
    "127.0.0.1" = [ "mydomain.test" "example.org" ];
  };
}
```

Which allows:

```console
[devshell]$ nc -v example.org 8080
nc: connect to example.org (127.0.0.1) port 8080 (tcp) failed: Connection refused
```