### PR TITLE
Add `shell.nix` to flake template

### DIFF
--- a/templates/toml/flake.nix
+++ b/templates/toml/flake.nix
@@ -4,7 +4,12 @@
   inputs.devshell.url = "github:numtide/devshell";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, flake-utils, devshell, nixpkgs }:
+  inputs.flake-compat = {
+    url = "github:edolstra/flake-compat";
+    flake = false;
+  };
+
+  outputs = { self, flake-utils, devshell, nixpkgs, ... }:
     flake-utils.lib.eachDefaultSystem (system: {
       devShell =
         let

--- a/templates/toml/shell.nix
+++ b/templates/toml/shell.nix
@@ -1,9 +1,25 @@
-let
-  scheme =
-    if builtins.pathExists ./.git
-    then "git+file"
-    else "path";
-in
-  (builtins.getFlake "${scheme}://${toString ./.}")
-  .devShell
-  .${builtins.currentSystem}
+# Use `builtins.getFlake` if available
+if builtins ? getFlake
+then
+  let
+    scheme =
+      if builtins.pathExists ./.git
+      then "git+file"
+      else "path";
+  in
+    (builtins.getFlake "${scheme}://${toString ./.}")
+    .devShell
+    .${builtins.currentSystem}
+
+# Otherwise we'll use the flake-compat shim
+else
+  (import
+    (
+      let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+    )
+    { src = ./.; }
+  ).shellNix

--- a/templates/toml/shell.nix
+++ b/templates/toml/shell.nix
@@ -1,0 +1,9 @@
+let
+  scheme =
+    if builtins.pathExists ./.git
+    then "git+file"
+    else "path";
+in
+  (builtins.getFlake "${scheme}://${toString ./.}")
+  .devShell
+  .${builtins.currentSystem}


### PR DESCRIPTION
This allows `nix-shell` to be used from tools that have not yet been updated to support flakes (ex: https://github.com/arrterian/nix-env-selector)
