### PR TITLE
feat(entrypoint): fixes/improvements to support `nix run` (devshell-as-flake-app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ development dependencies is as easy as:
 ```sh
 nix-build shell.nix | cachix push <mycache>
 ```
+
+### Runnable as a Nix application
+
+Devshells are runnable as Nix applications (via `nix run`).  This makes it
+possible to run commands defined in your devshell without entering a
+`nix-shell` or `nix develop` session:
+
+```sh
+nix run '.#<myapp>' -- <devshell-command> <and-args>
+```
+
+This project itself exposes a Nix application; you can try it out with:
+
+
+```sh
+nix run 'github:numtide/devshell' -- hello
+```
+
+See [here](docs/flake-app.md) for how to export your devshell as a flake app.
+
 ## TODO
 
 A lot of things!

--- a/docs/flake-app.md
+++ b/docs/flake-app.md
@@ -1,0 +1,66 @@
+# Using a devshell as a Nix application
+
+Devshells provide the attribute `flakeApp`, which contains an attribute set
+suitable for use as an entry in the `apps` flake output structure.  Export this
+attribute under `apps.<system>.<myapp>`, and then you can run commands within
+your devshell as follows:
+
+```sh
+nix run '.#<myapp>' -- <devshell-command> <and-args>
+```
+
+For example, given the following `flake.nix`:
+
+```nix
+{
+  inputs.devshell.url = "github:numtide/devshell";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, flake-utils, devshell, nixpkgs }:
+    flake-utils.lib.eachDefaultSystem (system: {
+      apps.devshell = self.outputs.devShells.${system}.default.flakeApp;
+
+      devShells.default =
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+
+            overlays = [ devshell.overlays.default ];
+          };
+        in
+        pkgs.devshell.mkShell ({ config, ... }: {
+          commands = [
+            {
+              name = "greet";
+              command = ''
+                printf -- 'Hello, %s!\n' "''${1:-world}"
+              '';
+            }
+          ];
+        });
+    });
+}
+```
+
+You can execute your devshell's `greet` command like this:
+
+```console
+$ nix run '.#devshell' -- greet myself
+Hello, myself!
+```
+
+## Setting `PRJ_ROOT`
+
+By default, the `PRJ_ROOT` environment variable is set to the value of the
+`PWD` environment variable.  You can override this by defining `PRJ_ROOT` in
+`nix run`'s environment:
+
+```sh
+PRJ_ROOT=/some/where/else nix run '.#<myapp>' -- <devshell-command> <and-args>
+```
+
+You can also use the `--prj-root` option:
+
+```sh
+nix run '.#<myapp>' -- --prj-root /yet/another/path -- <devshell-command> <and-args>
+```

--- a/flake.nix
+++ b/flake.nix
@@ -18,10 +18,6 @@
           }
       );
 
-      devShells = eachSystem (system: {
-        default = self.legacyPackages.${system}.fromTOML ./devshell.toml;
-      });
-
       templates = rec {
         toml = {
           path = ./templates/toml;
@@ -33,6 +29,15 @@
         };
         default = toml;
       };
+
+      devShells = eachSystem (system: {
+        default = self.legacyPackages.${system}.fromTOML ./devshell.toml;
+      });
+
+      apps = eachSystem (system: {
+        default = self.devShells.${system}.default.flakeApp;
+      });
+
       # Import this overlay into your instance of nixpkgs
       overlays.default = import ./overlay.nix;
       lib = {

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -313,7 +313,7 @@ in
       profile = cfg.package;
       passthru = {
         inherit config;
-        flakeApp = mkFlakeApp entrypoint;
+        flakeApp = mkFlakeApp "${devshell_dir}/entrypoint";
         hook = mkSetupHook entrypoint;
         inherit (config._module.args) pkgs;
       };

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -18,11 +18,11 @@ let
     program = "${bin}";
   };
 
-  mkSetupHook = entrypoint:
+  mkSetupHook = rc:
     pkgs.stdenvNoCC.mkDerivation {
       name = "devshell-setup-hook";
       setupHook = pkgs.writeText "devshell-setup-hook.sh" ''
-        source ${devshell_dir}/env.bash
+        source ${rc}
       '';
       dontUnpack = true;
       dontBuild = true;
@@ -314,7 +314,7 @@ in
       passthru = {
         inherit config;
         flakeApp = mkFlakeApp "${devshell_dir}/entrypoint";
-        hook = mkSetupHook entrypoint;
+        hook = mkSetupHook "${devshell_dir}/env.bash";
         inherit (config._module.args) pkgs;
       };
     };

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -108,7 +108,7 @@ let
 
     if [[ $# = 0 ]]; then
       # Start an interactive shell
-      exec "${bashPath}" --rcfile "$DEVSHELL_DIR/env.bash" --noprofile
+      set -- "${bashPath}" --rcfile "$DEVSHELL_DIR/env.bash" --noprofile
     elif [[ $1 == "-h" || $1 == "--help" ]]; then
       cat <<USAGE
     Usage: ${cfg.name}
@@ -123,12 +123,13 @@ let
     elif [[ $1 == "--pure" ]]; then
       # re-execute the script in a clean environment
       shift
-      exec /usr/bin/env -i -- ''${HOME:+"HOME=''${HOME:-}"} ''${PRJ_ROOT:+"PRJ_ROOT=''${PRJ_ROOT:-}"} "$0" "$@"
+      set -- /usr/bin/env -i -- ''${HOME:+"HOME=''${HOME:-}"} ''${PRJ_ROOT:+"PRJ_ROOT=''${PRJ_ROOT:-}"} "$0" "$@"
     else
       # Start a script
       source "$DEVSHELL_DIR/env.bash"
-      exec -- "$@"
     fi
+
+    exec -- "$@"
   '';
 
   # Builds the DEVSHELL_DIR with all the dependencies

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -60,11 +60,13 @@ let
   envBash = pkgs.writeText "devshell-env.bash" ''
     if [[ -n ''${IN_NIX_SHELL:-} || ''${DIRENV_IN_ENVRC:-} = 1 ]]; then
       # We know that PWD is always the current directory in these contexts
-      export PRJ_ROOT=$PWD
+      PRJ_ROOT=$PWD
     elif [[ -z ''${PRJ_ROOT:-} ]]; then
       echo "ERROR: please set the PRJ_ROOT env var to point to the project root" >&2
       return 1
     fi
+
+    export PRJ_ROOT
 
     # Expose the folder that contains the assembled environment.
     export DEVSHELL_DIR=@DEVSHELL_DIR@

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -124,6 +124,16 @@ let
 
           shift
           ;;
+        --env-bin)
+          if (( "$#" < 2 )); then
+            echo 1>&2 '${cfg.name}: missing required argument to --env-bin'
+            exit 1
+          fi
+
+          env_bin="$2"
+
+          shift
+          ;;
         --)
           shift
           break
@@ -146,6 +156,7 @@ let
     Options:
       * --pure            : execute the script in a clean environment
       * --prj-root <path> : set the project root (\$PRJ_ROOT)
+      * --env-bin <path>  : path to the env executable (default: /usr/bin/env)
     USAGE
       exit
     fi
@@ -161,7 +172,7 @@ let
       # short-circuit options processing on the second pass through this
       # script, in case we get something like:
       #   <entrypoint> --pure -- --pure <cmd>
-      set -- /usr/bin/env -i -- ''${HOME:+"HOME=''${HOME:-}"} ''${PRJ_ROOT:+"PRJ_ROOT=''${PRJ_ROOT:-}"} "$0" -- "$@"
+      set -- "''${env_bin:-/usr/bin/env}" -i -- ''${HOME:+"HOME=''${HOME:-}"} ''${PRJ_ROOT:+"PRJ_ROOT=''${PRJ_ROOT:-}"} "$0" -- "$@"
     else
       # Start a script
       source "$DEVSHELL_DIR/env.bash"

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -98,7 +98,7 @@ let
 
     # If the file is sourced, skip all of the rest and just source the env
     # script.
-    if [[ $0 != "''${BASH_SOURCE[0]}" ]]; then
+    if (return 0) &>/dev/null; then
       source "$DEVSHELL_DIR/env.bash"
       return
     fi

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -114,6 +114,16 @@ let
         --pure)
           pure=1
           ;;
+        --prj-root)
+          if (( "$#" < 2 )); then
+            echo 1>&2 '${cfg.name}: missing required argument to --prj-root'
+            exit 1
+          fi
+
+          PRJ_ROOT="$2"
+
+          shift
+          ;;
         --)
           shift
           break
@@ -134,7 +144,8 @@ let
       $0 [--pure] <cmd> [...] # run a command in the environment
 
     Options:
-      * --pure : execute the script in a clean environment
+      * --pure            : execute the script in a clean environment
+      * --prj-root <path> : set the project root (\$PRJ_ROOT)
     USAGE
       exit
     fi

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -123,7 +123,7 @@ let
     elif [[ $1 == "--pure" ]]; then
       # re-execute the script in a clean environment
       shift
-      exec /usr/bin/env -i -- "HOME=$HOME" "PRJ_ROOT=$PRJ_ROOT" "$0" "$@"
+      exec /usr/bin/env -i -- ''${HOME:+"HOME=''${HOME:-}"} ''${PRJ_ROOT:+"PRJ_ROOT=''${PRJ_ROOT:-}"} "$0" "$@"
     else
       # Start a script
       source "$DEVSHELL_DIR/env.bash"

--- a/modules/env.nix
+++ b/modules/env.nix
@@ -36,9 +36,17 @@ let
     };
 
     unset = mkEnableOption "unsets the variable";
+
+    __toString = mkOption {
+      type = types.functionTo types.str;
+      internal = true;
+      readOnly = true;
+      default = envToBash;
+      description = "Function used to translate this submodule to Bash code";
+    };
   };
 
-  envToBash = { name, value, eval, prefix, unset }@args:
+  envToBash = { name, value, eval, prefix, unset, ... }@args:
     let
       vals = filter (key: args.${key} != null && args.${key} != false) [
         "eval"
@@ -113,6 +121,6 @@ in
       }
     ];
 
-    devshell.startup_env = concatStringsSep "\n" (map envToBash config.env);
+    devshell.startup_env = concatStringsSep "\n" config.env;
   };
 }

--- a/tests/core/devshell.nix
+++ b/tests/core/devshell.nix
@@ -53,6 +53,9 @@
       shell = devshell.mkShell {
         devshell.name = "devshell-entrypoint-1";
         devshell.packages = [ pkgs.git ];
+
+        # Force PRJ_ROOT to be defined by caller (possibly via `--prj-root`).
+        devshell.prj_root_fallback = null;
       };
     in
     runTest "devshell-entrypoint-1" { } ''


### PR DESCRIPTION
I was poking at a `devshell` derivation in `nix repl` recently when I noticed its `flakeApp` attribute.  This is a cool feature!  I would love to be able to `nix run '.#my-devshell' -- <command>` and access commands from my devshell without having to first enter a `nix develop` sesson.  It looks like the `flakeApp` definition needs some updates to account for `devshell.nix` refactors; this PR is my attempt to apply those updates.  It also adds some convenience features, like a CLI option for specifying the project root path.

Have a few questions I'd like to resolve before removing "Draft" status from this PR:

1. Assuming you'd like to support `flakeApp`/`nix run`, where would you like me to document it?  I took a look at the files in `./docs` and nothing jumped out as an appropriate spot.
2. Any thoughts on whether it's possible or desirable to automatically infer a value for `PRJ_ROOT` when running the devshell entrypoint as a flake app?  Seems like `PRJ_ROOT` should refer to the flake's root directory?  For instance, maybe a devshell command references files in the flake by expanding them relative to `PRJ_ROOT`.  Using `PWD` as `PRJ_ROOT` in this circumstance might work, as long as `PWD` is the working tree toplevel of the git repository for the flake providing the devshell.  But it almost certainly wouldn't work if trying to `nix run 'some-other-flake#devshell-flake-app'`.  On the hand, maybe there are also cases where `PRJ_ROOT` should refer to (say) the current working directory -- for instance, maybe I want to run a linting command provided by a "foreign" flake, and that command searches for files that live under `PRJ_ROOT`.
3. One of the changes in this PR is exposing devshell's own devshell as the flake output `apps.<system>.devshell`, as a kind of demo of the `flakeApp` feature.  Is this worthwhile?  If so, should it be advertised somehow (in the README, or elsewhere)?

Thanks!

