### PR TITLE
repo: switch default branch to main

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,137 @@
+repository:
+  # See https://developer.github.com/v3/repos/#edit for all available settings.
+
+  # The name of the repository. Changing this will rename the repository
+  name: devshell
+
+  # A short description of the repository that will show up on GitHub
+  description: Per project developer environments
+
+  # A URL with more information about the repository
+  homepage: "https://numtide.github.io/devshell/"
+
+  # A comma-separated list of topics to set on the repository
+  topics: "toml, nix, direnv"
+
+  # Either `true` to make the repository private, or `false` to make it public.
+  private: false
+
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  has_issues: true
+
+  # Either `true` to enable projects for this repository, or `false` to disable them.
+  # If projects are disabled for the organization, passing `true` will cause an API error.
+  has_projects: false
+
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  has_wiki: true
+
+  # Either `true` to enable downloads for this repository, `false` to disable them.
+  has_downloads: false
+
+  # Updates the default branch for this repository.
+  default_branch: master
+
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: true
+
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: true
+
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: true
+
+  # Either `true` to enable automatic deletion of branches on merge, or `false` to disable
+  delete_branch_on_merge: true
+
+  # Either `true` to enable automated security fixes, or `false` to disable
+  # automated security fixes.
+  enable_automated_security_fixes: true
+
+  # Either `true` to enable vulnerability alerts, or `false` to disable
+  # vulnerability alerts.
+  enable_vulnerability_alerts: true
+
+# Labels: define labels for Issues and Pull Requests
+#
+labels:
+# NOTE: leave that up to the https://github.com/numtide/.github repo
+#   - name: bug
+#     color: CC0000
+#     description: An issue with the system 🐛.
+
+#   - name: feature
+#     # If including a `#`, make sure to wrap it with quotes!
+#     color: '#336699'
+#     description: New functionality.
+
+#   - name: Help Wanted
+#     # Provide a new name to rename an existing label
+#     new_name: first-timers-only
+
+# Milestones: define milestones for Issues and Pull Requests
+milestones:
+#   - title: milestone-title
+#     description: milestone-description
+#     # The state of the milestone. Either `open` or `closed`
+#     state: open
+
+# Collaborators: give specific users access to this repository.
+# See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
+collaborators:
+  # - username: xxx
+    # Note: `permission` is only valid on organization-owned repositories.
+    # The permission to grant the collaborator. Can be one of:
+    # * `pull` - can pull, but not push to or administer this repository.
+    # * `push` - can pull and push, but not administer this repository.
+    # * `admin` - can pull, push and administer this repository.
+    # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+    # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
+    # permission: push
+
+# See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
+teams:
+  - name: network
+    # The permission to grant the team. Can be one of:
+    # * `pull` - can pull, but not push to or administer this repository.
+    # * `push` - can pull and push, but not administer this repository.
+    # * `admin` - can pull, push and administer this repository.
+    # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+    # * `triage` - Recommended for contributors who need to proactively manage issues and pull requests without write access.
+    permission: maintain
+
+branches:
+  - name: main
+    # https://docs.github.com/en/rest/reference/repos#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+      required_pull_request_reviews:
+        # # The number of approvals required. (1-6)
+        # required_approving_review_count: 1
+        # # Dismiss approved reviews automatically when a new commit is pushed.
+        # dismiss_stale_reviews: true
+        # # Blocks merge until code owners have reviewed.
+        # require_code_owner_reviews: true
+        # # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
+        # dismissal_restrictions:
+        #   users: []
+        #   teams: []
+      # Required. Require status checks to pass before merging. Set to null to disable
+      required_status_checks:
+        # Required. Require branches to be up to date before merging.
+        strict: true
+        # Required. The list of status checks to require in order to merge into this branch
+        contexts: [ "bors" ]
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: false
+      # Disabled for bors to work
+      required_linear_history: false
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+      restrictions:
+        apps: [ "bors" ]
+        users: []
+        teams: []

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -2,7 +2,7 @@ name: goreleaser
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - 'v*'
   workflow_dispatch:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,7 +2,7 @@ name: Nix
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 jobs:
@@ -62,7 +62,7 @@ jobs:
           nix-build -A docs
           cp -r "$(readlink ./result)" book
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: crazy-max/ghaction-github-pages@v3
         with:
           target_branch: gh-pages

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,4 @@
+cut_body_after = "" # don't include text from the PR body in the merge commit message
+status = [
+  "Evaluate flake.nix",
+]

--- a/devshell/cmd/enter.go
+++ b/devshell/cmd/enter.go
@@ -48,7 +48,7 @@ var Enter = &cli.Command{
 		&cli.StringSliceFlag{
 			Name:  "I",
 			Usage: "Add a path to the NIX_PATH",
-			Value: cli.NewStringSlice("devshell=https://github.com/numtide/devshell/archive/master.tar.gz"),
+			Value: cli.NewStringSlice("devshell=https://github.com/numtide/devshell/archive/main.tar.gz"),
 		},
 	},
 	Action: func(c *cli.Context) error {

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,4 +8,4 @@ title = "devshell"
 [output.html]
 # Show github links in top bar
 git-repository-url = "https://github.com/numtide/devshell"
-edit-url-template = "https://github.com/numtide/devshell/edit/master/docs/{path}"
+edit-url-template = "https://github.com/numtide/devshell/edit/main/docs/{path}"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -16,13 +16,13 @@ contain some nix code. Don't worry about the details.
 ```nix
 { system ? builtins.currentSystem }:
 let
-  src = fetchTarball "https://github.com/numtide/devshell/archive/master.tar.gz";
+  src = fetchTarball "https://github.com/numtide/devshell/archive/main.tar.gz";
   devshell = import src { inherit system; };
 in
 devshell.fromTOML ./devshell.toml
 ```
 
-> NOTE: it's probably a good idea to pin the dependency by replacing `master` with a git commit ID.
+> NOTE: it's probably a good idea to pin the dependency by replacing `main` with a git commit ID.
 
 Now you can enter the developer shell for the project:
 

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -13,7 +13,7 @@ let
       config.modules-docs.roots = [{
         url = "https://github.com/numtide/devshell";
         path = toString ../.;
-        branch = "master";
+        branch = "main";
       }];
     }
   ];


### PR DESCRIPTION
Avoid issues when copy-pasting workflows and settings between repos.