### PR TITLE
fix: update deprecated default flake outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,15 +21,15 @@
         };
       in
       {
-        defaultPackage = pkgs.cli;
+        packages.default = pkgs.cli;
         legacyPackages = pkgs;
-        devShell = pkgs.fromTOML ./devshell.toml;
+        devShells.default = pkgs.fromTOML ./devshell.toml;
       }
     ) // {
-      defaultTemplate.path = ./template;
-      defaultTemplate.description = "nix flake new 'github:numtide/devshell'";
+      templates.default.path = ./template;
+      templates.default.description = "nix flake new 'github:numtide/devshell'";
       # Import this overlay into your instance of nixpkgs
-      overlay = import ./overlay.nix;
+      overlays.default = import ./overlay.nix;
       lib = {
         importTOML = import ./nix/importTOML.nix;
       };


### PR DESCRIPTION
Fixes the following warnings:

```shell
❯ nix flake check
warning: flake output attribute 'defaultPackage' is deprecated; use 'packages.<system>.default' instead
warning: flake output attribute 'devShell' is deprecated; use 'devShells.<system>.default' instead
warning: flake output attribute 'defaultTemplate' is deprecated; use 'templates.default' instead
warning: flake output attribute 'overlay' is deprecated; use 'overlays.default' instead
```