### PR TITLE
feat/bump nixpkgs

### DIFF
--- a/extra/git/hooks.nix
+++ b/extra/git/hooks.nix
@@ -32,7 +32,7 @@ let
   # shims read the correct "real" shim (directory) from DEVSHELL_GIT_HOOKS_DIR,
   # which points to the directory containing git hooks for the current
   # devshell.
-  hookShimsDir = pkgs.runCommand "git.hook.shims" {} ''
+  hookShimsDir = pkgs.runCommand "git.hook.shims" { } ''
     mkdir -p $out/bin
 
     ${lib.concatMapStringsSep "\n" (k: ''

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643381941,
-        "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
+        "lastModified": 1677383253,
+        "narHash": "sha256-UfpzWfSxkfXHnb4boXZNaKsAcUrZT9Hw+tao1oZxd08=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5efc8ca954272c4376ac929f4c5ffefcc20551d5",
+        "rev": "9952d6bc395f5841262b006fbace8dd7e143b634",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,20 +12,21 @@
       "i686-linux"
       "x86_64-darwin"
       "x86_64-linux"
-    ] (system:
-      let
-        pkgs = import inputs.self {
-          inherit system;
-          inputs = null;
-          nixpkgs = inputs.nixpkgs.legacyPackages.${system};
-        };
-      in
-      {
-        packages.default = pkgs.cli;
-        legacyPackages = pkgs;
-        devShells.default = pkgs.fromTOML ./devshell.toml;
-      }
-    ) // {
+    ]
+      (system:
+        let
+          pkgs = import inputs.self {
+            inherit system;
+            inputs = null;
+            nixpkgs = inputs.nixpkgs.legacyPackages.${system};
+          };
+        in
+        {
+          packages.default = pkgs.cli;
+          legacyPackages = pkgs;
+          devShells.default = pkgs.fromTOML ./devshell.toml;
+        }
+      ) // {
       templates.default.path = ./template;
       templates.default.description = "nix flake new 'github:numtide/devshell'";
       # Import this overlay into your instance of nixpkgs

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -218,7 +218,7 @@ in
 
     meta = mkOption {
       type = types.attrsOf types.anything;
-      default = {};
+      default = { };
       description = ''
         Metadata, such as 'meta.description'. Can be useful as metadata for downstream tooling.
       '';

--- a/nix/writeDefaultShellScript.nix
+++ b/nix/writeDefaultShellScript.nix
@@ -23,5 +23,5 @@ writeTextFile (
     executable = true;
   }
   // (lib.optionalAttrs (checkPhase != null) { inherit checkPhase; })
-  // (lib.optionalAttrs binPrefix { destination = "/bin/${name}"; })
+    // (lib.optionalAttrs binPrefix { destination = "/bin/${name}"; })
 )

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -7,11 +7,12 @@
   outputs = { self, flake-utils, devshell, nixpkgs }:
     flake-utils.lib.eachDefaultSystem (system: {
       devShell =
-        let pkgs = import nixpkgs {
-          inherit system;
+        let
+          pkgs = import nixpkgs {
+            inherit system;
 
-          overlays = [ devshell.overlay ];
-        };
+            overlays = [ devshell.overlay ];
+          };
         in
         pkgs.devshell.mkShell {
           imports = [ (pkgs.devshell.importTOML ./devshell.toml) ];


### PR DESCRIPTION
When running `nixpkgs-fmt` I was getting the following:

```shell
❯ nixpkgs-fmt ./
nixpkgs-fmt: /nix/store/saw6nkqqqfx5xm1h5cpk7gxnxmw9wk47-glibc-2.33-62/lib/libc.so.6: version `GLIBC_2.34' not found (required by /nix/store/sq78g74zs4sj7n1j5709g9c2pmffx1y8-gcc-11.3.0-lib/lib/libgcc_s.so.1)
```

When I checked the lock file for `nixpkgs` I noticed it hadn't been updated in about a year. Bumping `nixpkgs` seems to have resolved the problem. 