### PR TITLE
Update the template.nix to use new default overlay

### DIFF
--- a/template/flake.nix
+++ b/template/flake.nix
@@ -11,7 +11,7 @@
           pkgs = import nixpkgs {
             inherit system;
 
-            overlays = [ devshell.overlay ];
+            overlays = [ devshell.overlays.default ];
           };
         in
         pkgs.devshell.mkShell {


### PR DESCRIPTION
Updates the template.nix to use the default overlays, from https://github.com/numtide/devshell/commit/0c89450ba8935d9b1241e1ad42d4c870f123e142.

After running:
`nix develop` on a new project, `nix flake new -t "github:numtide/devshell" .`
I get the following error:
```
error: attribute 'overlay' missing

       at /nix/store/a1nqfp20418q28hwks7dn86r1d45kjm7-source/demos/temporal/flake.nix:14:26:

           13|
           14|             overlays = [ devshell.overlay ];
             |                          ^
           15|           };
       Did you mean overlays?
(use '--show-trace' to show detailed location information)
```
Hopefully this is enough to solve the issue.