### PR TITLE
fix: find Nix store dir with `builtins.storeDir`

### DIFF
--- a/modules/modules-docs.nix
+++ b/modules/modules-docs.nix
@@ -65,7 +65,7 @@ let
     if root == null then
     # We need to strip references to /nix/store/* from the options or
     # else the build will fail.
-      { path = removePrefix "${builtins.storePath}/" decl; url = ""; }
+      { path = removePrefix "${builtins.storeDir}/" decl; url = ""; }
     else
       rec {
         path = removePrefix root.prefix decl;


### PR DESCRIPTION
rather than attempting to do so with `builtins.storePath`, which is for "defin[ing] a dependency on an already existing store path" (https://nixos.org/manual/nix/stable/language/builtins.html#builtins-storePath).