### PR TITLE
Revert to manual quoting to make sure env variables can be used as part of other env variables when prefixing

### DIFF
--- a/modules/env.nix
+++ b/modules/env.nix
@@ -64,7 +64,7 @@ let
     else if valType == "eval" then
       "export ${name}=${eval}"
     else if valType == "prefix" then
-      ''export ${name}=$(${pkgs.coreutils}/bin/realpath --canonicalize-missing ${escapeShellArg prefix})''${${name}+:''${${name}}}''
+      ''export ${name}=$(${pkgs.coreutils}/bin/realpath --canonicalize-missing "${prefix}")''${${name}+:''${${name}}}''
     else if valType == "unset" then
       ''unset ${name}''
     else

--- a/tests/extra/language.c.nix
+++ b/tests/extra/language.c.nix
@@ -16,4 +16,20 @@
       # Has a C compiler
       type -p clang
     '';
+  # Test good LD_LIBRARY_PATH value
+  language-c-2 =
+    let
+      shell = devshell.mkShell {
+        imports = [ ../../extra/language/c.nix ];
+        devshell.name = "devshell-2";
+        language.c.libraries = [ pkgs.openssl ];
+      };
+    in
+    runTest "language-c-2" { } ''
+      # Load the devshell
+      source ${shell}/env.bash
+
+      # LD_LIBRARY_PATH is evaluated correctly
+      [[ ! "$LD_LIBRARY_PATH" =~ "DEVSHELL_DIR" ]]
+    '';
 }


### PR DESCRIPTION
Revert "Prefer escapeShellArg over manual quoting"

This reverts commit a773f912ea85cdfa04a13070431abfc0c19ce79f.

Fixes #258.