### PR TITLE
fix: use devShells.default on template flake

### DIFF
--- a/templates/toml/flake.nix
+++ b/templates/toml/flake.nix
@@ -11,7 +11,7 @@
 
   outputs = { self, flake-utils, devshell, nixpkgs, ... }:
     flake-utils.lib.eachDefaultSystem (system: {
-      devShell =
+      devShells.default =
         let
           pkgs = import nixpkgs {
             inherit system;

--- a/templates/toml/shell.nix
+++ b/templates/toml/shell.nix
@@ -8,8 +8,9 @@ then
       else "path";
   in
     (builtins.getFlake "${scheme}://${toString ./.}")
-    .devShell
+    .devShells
     .${builtins.currentSystem}
+    .default
 
 # Otherwise we'll use the flake-compat shim
 else


### PR DESCRIPTION
When using `nix flake check`, we get a deprecated warning:

```
> nix flake check
warning: updating lock file '/tmp/devshell/templates/toml/flake.lock':
• Added input 'flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
warning: flake output attribute 'devShell' is deprecated; use 'devShells.<system>.default' instead
```

This PR fixes this warning.