### PR TITLE
perl: use makeFullPerlPath

### DIFF
--- a/extra/language/perl.nix
+++ b/extra/language/perl.nix
@@ -32,7 +32,7 @@ with lib;
     env = [
       (mkIf (cfg.extraPackages != []) {
         name = "PERL5LIB";
-        prefix = pkgs.perlPackages.makePerlPath cfg.extraPackages;
+        prefix = pkgs.perlPackages.makeFullPerlPath cfg.extraPackages;
       })
       (mkIf (cfg.libraryPaths != []) {
         name = "PERL5LIB";


### PR DESCRIPTION
Before that, the `PERL5LIB` was pointing to the specified libraries, but it was also ignoring all of their dependencies. After checking the [NixOS Wiki](https://nixos.wiki/wiki/Perl) guide for Perl, found out that it needs to use `makeFullPerlPath` instead.