### PR TITLE
services: Add quotes around $PRJ_ROOT to allow for paths with spaces

### DIFF
--- a/modules/services.nix
+++ b/modules/services.nix
@@ -58,7 +58,7 @@ let
             exit 1
           fi
           mkdir -p "$PRJ_DATA_DIR/pids/"
-          ${pkgs.honcho}/bin/honcho start -f ${procfile} -d $PRJ_ROOT &
+          ${pkgs.honcho}/bin/honcho start -f ${procfile} -d "$PRJ_ROOT" &
           pid=$!
           echo $pid > "$PRJ_DATA_DIR/pids/${gName}.pid"
           on_stop() {


### PR DESCRIPTION
## description

Without quotes, if `$PWD` has spaces, then `my_service_name:start` would fail with something like `Process type 'stuff_after_a_space_char' does not exist in Procfile`.
