### PR TITLE
go: add GOPATH option

### DIFF
--- a/extra/language/go.nix
+++ b/extra/language/go.nix
@@ -18,13 +18,26 @@ with lib;
       example = literalExpression "pkgs.go";
       description = "Which go package to use";
     };
+
+    GOPATH = mkOption {
+      type = types.either types.path types.str;
+      default = "$HOME/go";
+      example = literalExpression "/home/user/go";
+      description = "Path to your go directory";
+    };
   };
 
   config = {
-    env = [{
-      name = "GO111MODULE";
-      value = cfg.GO111MODULE;
-    }];
+    env = [
+      {
+        name = "GO111MODULE";
+        value = cfg.GO111MODULE;
+      }
+      {
+        name = "GOPATH";
+        eval = cfg.GOPATH;
+      }
+    ];
 
     devshell.packages = [ cfg.package ];
   };


### PR DESCRIPTION
Needed to add this option because on the workplace I have to create a separate path for my Go directory.

I am using `null` as default value here because as `GOPATH` must be an absolute path (it complains it if is relative), using `$HOME/go` as a default value is not a good idea. 