### PR TITLE
Expose `specialArgs.modulesPath` and `specialArgs.extraModulesPath` to flake module consumers

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -41,7 +41,15 @@ jobs:
           name: numtide
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix flake check
-      - run: nix develop -c echo OK
+      - name: Run devshell entry sanity checks
+        run: |
+          nix develop -c echo OK
+          for tmpl in ./templates/*; do
+            if ! [ -d "$tmpl" ]; then
+              continue
+            fi
+            nix develop --override-input devshell . "$tmpl" -c echo OK
+          done
       - name: Run nix flake archive
         run: nix flake archive
   docs:

--- a/default.nix
+++ b/default.nix
@@ -33,14 +33,17 @@ let
 in
 rec {
   # Folder that contains all the extra modules
-  extraModulesDir = toString ./extra;
+  extraModulesPath = toString ./extra;
+
+  # Alias for backward compatibility.
+  extraModulesDir = extraModulesPath;
 
   # Get the modules documentation from an empty evaluation
   modules-docs =
     (eval {
       configuration = {
         # Load all of the extra modules so they appear in the docs
-        imports = importTree extraModulesDir;
+        imports = importTree extraModulesPath;
       };
     }).config.modules-docs;
 

--- a/docs/src/extending.md
+++ b/docs/src/extending.md
@@ -31,7 +31,9 @@ lang = "en_US.UTF-8"
 From a nix flake you would import it like
 
 ```nix
-imports = ["${devshell}/extra/locale.nix"];
+devshell.mkShell ({ extraModulesPath, ... }: {
+  imports = ["${extraModulesPath}/locale.nix"];
+})
 ```
 
 ## Building your own modules

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -21,7 +21,7 @@ in
           '';
 
           type = types.lazyAttrsOf (
-            types.submoduleWith { modules = import ./modules/modules.nix { inherit pkgs lib; }; }
+            types.submoduleWith (import ./modules/eval-args.nix { inherit pkgs lib; })
           );
           default = { };
         };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -6,18 +6,13 @@ nixpkgs:
   extraSpecialArgs ? { },
 }:
 let
-  devenvModules = import ./modules.nix {
-    pkgs = nixpkgs;
-    inherit lib;
-  };
-
-  module = lib.evalModules {
-    modules = [ configuration ] ++ devenvModules;
-    specialArgs = {
-      modulesPath = builtins.toString ./.;
-      extraModulesPath = builtins.toString ../extra;
-    } // extraSpecialArgs;
-  };
+  module = lib.evalModules (
+    import ./eval-args.nix {
+      inherit lib extraSpecialArgs;
+      pkgs = nixpkgs;
+      modules = [ configuration ];
+    }
+  );
 in
 {
   inherit (module) config options;

--- a/modules/eval-args.nix
+++ b/modules/eval-args.nix
@@ -1,0 +1,17 @@
+# Arguments for `lib.evalModules` or `types.submoduleWith`.
+{
+  pkgs,
+  lib,
+  modules ? [ ],
+  extraSpecialArgs ? { },
+}:
+let
+  devenvModules = import ./modules.nix { inherit lib pkgs; };
+in
+{
+  modules = (lib.toList modules) ++ devenvModules;
+  specialArgs = {
+    modulesPath = builtins.toString ./.;
+    extraModulesPath = builtins.toString ../extra;
+  } // extraSpecialArgs;
+}

--- a/nix/importTOML.nix
+++ b/nix/importTOML.nix
@@ -7,14 +7,14 @@ let
       dir = toString (builtins.dirOf file);
       data = builtins.fromTOML (builtins.readFile file);
 
-      extraModulesDir = toString ../extra;
-      extraModules = builtins.readDir extraModulesDir;
+      extraModulesPath = toString ../extra;
+      extraModules = builtins.readDir extraModulesPath;
 
       importModule =
         str:
         let
           repoFile = "${dir}/${str}";
-          extraFile = "${extraModulesDir}/${builtins.replaceStrings [ "." ] [ "/" ] str}.nix";
+          extraFile = "${extraModulesPath}/${builtins.replaceStrings [ "." ] [ "/" ] str}.nix";
         in
         # First try to import from the user's repository
         if lib.hasPrefix "./" str || lib.hasSuffix ".nix" str || lib.hasSuffix ".toml" str then

--- a/templates/flake-parts/flake.nix
+++ b/templates/flake-parts/flake.nix
@@ -25,7 +25,25 @@
       perSystem =
         { pkgs, ... }:
         {
-          devshells.default = { };
+          devshells.default = (
+            { extraModulesPath, ... }@args:
+            {
+              # `extraModulesPath` provides access to additional modules that are
+              # not included in the standard devshell modules list.
+              #
+              # Please see https://numtide.github.io/devshell/extending.html for
+              # documentation on consuming extra modules, and see
+              # https://github.com/numtide/devshell/tree/main/extra for the
+              # extra modules that are currently available.
+              imports = [ "${extraModulesPath}/git/hooks.nix" ];
+
+              git.hooks.enable = false;
+              git.hooks.pre-commit.text = ''
+                echo 1>&2 'time to implement a pre-commit hook!'
+                exit 1
+              '';
+            }
+          );
         };
     };
 }


### PR DESCRIPTION
This PR factors out the construction of `specialArgs`, making those arguments available to flake module users as well as to users of `devshell.mkShell`.

Associated changes include:
1. Replacing uses of the name `extraModulesDir` with `extraModulesPath`, to harmonize with the name of the `specialArgs` entry,
2. Documentation of `extraModulesPath` usage, 
3. Demoing the use of `extraModulesPath` in the `flake-parts`-based flake template, and
4. Running the basic `nix develop <...> -c echo OK` sanity-check on all flake templates (thus testing that the `extraModulesPath` in the `flake-parts`-based template hasn't broken anything too badly).

Thank you!