### PR TITLE
feat: add hare language support

### DIFF
--- a/extra/language/hare.nix
+++ b/extra/language/hare.nix
@@ -1,0 +1,58 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.language.hare;
+  strOrPackage = import ../../nix/strOrPackage.nix {inherit lib pkgs;};
+  makeHareFullPath = thirdParty: let
+    allHareThirdPartyPkgs = builtins.attrValues (pkgs.hareThirdParty.packages pkgs);
+    isPropagatedLib = drv: builtins.any (x: drv == x) allHareThirdPartyPkgs;
+    pkgsPropagatedBuildInputs = builtins.foldl' (acc: e: acc ++ e.propagatedBuildInputs) [] thirdParty;
+    propagatedLibs = builtins.filter isPropagatedLib pkgsPropagatedBuildInputs;
+  in
+    lib.makeSearchPath
+    "src/hare/third-party"
+    (thirdParty ++ propagatedLibs);
+in
+  with lib; {
+    options.language.hare = {
+      thirdPartyLibs = mkOption {
+        type = types.listOf strOrPackage;
+        default = [];
+        example = literalExpression "[ hareThirdParty.hare-compress ]";
+        description = "List of extra packages (coming from hareThirdParty) to add";
+      };
+      vendoredLibs = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = literalExpression "[ ./vendor/lib ]";
+        description = "List of paths to add to HAREPATH";
+      };
+      package = mkOption {
+        type = strOrPackage;
+        default = pkgs.hare;
+        example = literalExpression "pkgs.hare";
+        description = "Which Hare package to use";
+      };
+    };
+
+    config = {
+      env = [
+        (mkIf (cfg.thirdPartyLibs != [] || cfg.vendoredLibs != []) {
+          name = "HAREPATH";
+          value = lib.makeSearchPath "src/hare/stdlib" [cfg.package];
+        })
+        (mkIf (cfg.thirdPartyLibs != []) {
+          name = "HAREPATH";
+          prefix = makeHareFullPath cfg.thirdPartyLibs;
+        })
+        (mkIf (cfg.vendoredLibs != []) {
+          name = "HAREPATH";
+          prefix = concatStringsSep ":" cfg.vendoredLibs;
+        })
+      ];
+      devshell.packages = [cfg.package];
+    };
+  }

--- a/tests/extra/language.hare.nix
+++ b/tests/extra/language.hare.nix
@@ -1,0 +1,56 @@
+{
+  pkgs,
+  devshell,
+  runTest,
+}: {
+  # Basic test
+  language-hare-1 = let
+    shell = devshell.mkShell {
+      imports = [../../extra/language/hare.nix];
+      devshell.name = "devshell-1";
+    };
+  in
+    runTest "language-hare-1" {} ''
+      # Load the devshell
+      source ${shell}/env.bash
+
+      # Has a Hare binary
+      type -p hare
+    '';
+  # Test good HAREPATH value
+  # TODO: When the nixpkgs input is updated, change hare-ev to hare-png, so
+  # that the inclusion of propagatedBuildInputs third-party libraries is also tested.
+  language-hare-2 = let
+    shell = devshell.mkShell {
+      imports = [../../extra/language/hare.nix];
+      devshell.name = "devshell-2";
+      language.hare = {
+        thirdPartyLibs = [pkgs.hareThirdParty.hare-compress];
+        vendoredLibs = ["./vendor/lib"];
+      };
+    };
+  in
+    runTest "language-hare-2" {} ''
+      # Load the devshell
+      source ${shell}/env.bash
+
+      die() {
+        printf -- '%s\n' "''${*}" 2>&1
+        printf -- 'HAREPATH: `%s`\n' ''${HAREPATH//:/ } 2>&1
+        exit 1
+      }
+
+      # Check for HAREPATH being set
+      [[ -n "$HAREPATH" ]] || die "HAREPATH not set"
+
+      # Check for the stdlib being included in HAREPATH
+      [[ "$HAREPATH" =~ "src/hare/stdlib" ]] || die 'HAREPATH lacks `stdlib`'
+
+      # Check for hare-ev being included in HAREPATH
+      [[ "$HAREPATH" =~ /nix/store/[a-z0-9]{32}-hare-compress-.*/src/hare/third-party ]] \
+        || die 'HAREPATH lacks `hare-compress`'
+
+      # Check for ./vendor/lib being included in HAREPATH
+      [[ "$HAREPATH" =~ $PWD/vendor/lib ]] || die "HAREPATH lacks \`$PWD/vendor/lib\`"
+    '';
+}


### PR DESCRIPTION
The module, besides providing the Hare binary through
`devshell.packages`, exposes the following options:

1. `thirdPartyLibs`: add hare third-party libraries
   (pkgs.hareThirdParty) to the HAREPATH environment variable.
2. `vendoredLibs`: add vendored libraries (any path on the project repo)
   to HAREPATH.
3. `package`: set which `hare` package to use (defaults to `pkgs.hare`).

Regarding third-party libraries, the module also takes care of the ones
included on `propagatedBuildInputs`, by adding them to HAREPATH.
