### PR TITLE
init compatibility with: nix bundle, nix run, lib.getExe

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,7 @@ nix-build shell.nix | cachix push <mycache>
 
 ### Runnable as a Nix application
 
-Devshells are runnable as Nix applications (via `nix run`).  This makes it
-possible to run commands defined in your devshell without entering a
-`nix-shell` or `nix develop` session:
+Devshells are runnable (via `nix run`).  This makes it possible to run commands defined in your devshell without entering a `nix-shell` or `nix develop` session:
 
 ```sh
 nix run '.#<myapp>' -- <devshell-command> <and-args>
@@ -132,7 +130,7 @@ This project itself exposes a Nix application; you can try it out with:
 nix run 'github:numtide/devshell' -- hello
 ```
 
-See [here](docs/flake-app.md) for how to export your devshell as a flake app.
+See [here](docs/src/flake-app.md) for more details.
 
 ## TODO
 

--- a/docs/src/flake-app.md
+++ b/docs/src/flake-app.md
@@ -1,12 +1,16 @@
-# Using a devshell as a Nix application
+# Using a devshell as a Nix package
 
-Devshells provide the attribute `flakeApp`, which contains an attribute set
-suitable for use as an entry in the `apps` flake output structure.  Export this
-attribute under `apps.<system>.<myapp>`, and then you can run commands within
-your devshell as follows:
+Devshells can be treated as executable packages. This allows running commands inside a devshell's environment without having to enter it first via `nix-shell` or `nix develop`.
+
+Each devshell in a flake can be executed using nix run:
+```sh
+nix run '.#devShells.<system>.<myshell>' -- <devshell-command> <and-args>
+```
+
+To simplify this command further, re-expose the devshell under `packages.<system>.<myshell>`. This allows running it like this:
 
 ```sh
-nix run '.#<myapp>' -- <devshell-command> <and-args>
+nix run '.#<myshell>' -- <devshell-command> <and-args>
 ```
 
 For example, given the following `flake.nix`:
@@ -18,7 +22,7 @@ For example, given the following `flake.nix`:
 
   outputs = { self, flake-utils, devshell, nixpkgs }:
     flake-utils.lib.eachDefaultSystem (system: {
-      apps.devshell = self.outputs.devShells.${system}.default.flakeApp;
+      packages.devshell = self.outputs.devShells.${system}.default;
 
       devShells.default =
         let

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,8 @@
                 'nix-instantiate ./nixpkgs-mkshell.nix'
             '';
           };
+          # expose devshell as an executable package
+          default = devShells.default;
         };
 
         devShells.default = devshell.fromTOML ./devshell.toml;
@@ -45,8 +47,6 @@
           inputs = null;
           nixpkgs = pkgs;
         };
-
-        apps.default = devShells.default.flakeApp;
 
         checks =
           with pkgs.lib;

--- a/tests/core/devshell.nix
+++ b/tests/core/devshell.nix
@@ -80,4 +80,20 @@
       # Packages available through entrypoint in pure mode
       entrypoint_clean --pure --env-bin env --prj-root . /bin/sh -c 'type -p git'
     '';
+
+  # Use devshell as executable
+  devshell-executable-1 =
+    let
+      shell = devshell.mkShell {
+        devshell.name = "devshell-executable-1";
+        devshell.packages = [ pkgs.hello ];
+      };
+    in
+    runTest "devshell-executable-1" { } ''
+      # Devshell is executable
+      assert -x ${pkgs.lib.getExe shell}
+
+      # Packages inside the devshell are executable
+      ${pkgs.lib.getExe shell} hello
+    '';
 }


### PR DESCRIPTION
This makes all devshells compatible with `lib.getExe`, `nix run`and `nix bundle` by setting `meta.mainProgram` and creating an executable under `$out/bin/${meta.mainProgram}`

Also remove the now unnecessary flakeApp workaround from the docs and replace it with updated instructions.

My main motivation behind this is to create portable executable devshells via `nix bundle`.
For example, to bundle the devShell of devshell itself into a static executable:

```sh
nix bundle --bundler github:DavHau/nix-portable github:numtide/devshell#devShells.x86_64-linux.default
```
