### PR TITLE
feat(postgres): add `commands` configs

### DIFF
--- a/extra/services/postgres.nix
+++ b/extra/services/postgres.nix
@@ -80,8 +80,6 @@ in
   config = {
     packages = [
       cfg.package
-      setup-postgres
-      start-postgres
     ];
 
     env = [
@@ -98,5 +96,19 @@ in
     devshell.startup.setup-postgres.text = lib.optionalString cfg.setupPostgresOnStartup ''
       ${setup-postgres}/bin/setup-postgres
     '';
+
+    commands = [
+      {
+        name = "setup-postgres";
+        package = setup-postgres;
+        help = "Setup the postgres data directory";
+      }
+      {
+        name = "start-postgres";
+        package = start-postgres;
+        help = "Start the postgres server";
+        category = "databases";
+      }
+    ];
   };
 }


### PR DESCRIPTION
right now `setup-postgres` and `start-postgres` are added to the user's dev shell, but there's little documentation about even the existence of these utilities. since they're non-standard utilities (that is, they aren't defined by `pkgs.postgresql`), it's non-ideal leaving them undocumented

this solution isn't *ideal* because the categories are subjective to my own categorization method, but this greatly improves ux

an even better solution would be to refactor the `commands` option to accept and attrset of `<name> = <command config>`, which would allow the user to respec the categories