### PR TITLE
Cleanly stop a service group if a service exits

### DIFF
--- a/modules/services.nix
+++ b/modules/services.nix
@@ -77,7 +77,7 @@ let
                 rm "$PRJ_DATA_DIR/pids/${gName}.pid"
                 wait $pid
             }
-            trap "on_stop" SIGINT SIGTERM SIGHUP
+            trap "on_stop" SIGINT SIGTERM SIGHUP EXIT
             wait $pid
           '').outPath;
       }

--- a/modules/services.nix
+++ b/modules/services.nix
@@ -73,7 +73,9 @@ let
             pid=$!
             echo $pid > "$PRJ_DATA_DIR/pids/${gName}.pid"
             on_stop() {
-                kill -TERM $pid
+                if ps -p $pid > /dev/null; then
+                  kill -TERM $pid
+                fi
                 rm "$PRJ_DATA_DIR/pids/${gName}.pid"
                 wait $pid
             }


### PR DESCRIPTION
This fixes a small issue with service groups (that I noticed a few months ago and forgot about myself).

If a service in a group encounters an `EXIT` the whole group stops, but the pidfile isn't cleaned up. To start the service again I would then have to call `service:stop` and `service:start`.  By trapping `EXIT`, we also cleanly stop the group and will clean up the pidfile.

I also added a check to see if the process is still running before killing is. Otherwise we'd get a print saying that the process doesn't exist:
```
09:16:06 system | ruby.1 started (pid=61570)
09:16:06 ruby.1 | main fn
09:16:06 system | ruby.1 stopped (rc=0)
/nix/store/kslx6csgb2bl13sp438vsx5kiq7s788c-example-services-start: line 11: kill: (61565) - No such process
```

A minimal reproduction of this issue can be found here: https://git.robbevp.be/robbevp/devshell-ruby-reproduction
Updating the devshell input to this branch fixes the issue.