### PR TITLE
feat(flake-module)!: a flake check for each devshell

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -25,7 +25,12 @@ in
           );
           default = { };
         };
-        config.devShells = lib.mapAttrs (_name: devshell: devshell.devshell.shell) config.devshells;
+        config = {
+          devShells = lib.mapAttrs (_name: devshell: devshell.devshell.shell) config.devshells;
+          checks = lib.mapAttrs' (
+            name: devshell: lib.nameValuePair "devshells/${name}" devshell.devshell.shell
+          ) config.devshells;
+        };
       }
     );
   };


### PR DESCRIPTION
Here is a `nix flake show`

```
git+file:///home/mightyiam/s/numtide/devshell?dir=templates/flake-parts
├───checks
│   ├───aarch64-darwin
│   │   └───"devshells/default" omitted (use '--all-systems' to show)
│   ├───aarch64-linux
│   │   └───"devshells/default" omitted (use '--all-systems' to show)
│   ├───i686-linux
│   │   └───"devshells/default" omitted (use '--all-systems' to show)
│   ├───x86_64-darwin
│   │   └───"devshells/default" omitted (use '--all-systems' to show)
│   └───x86_64-linux
│       └───"devshells/default": derivation 'devshell'
└───devShells
    ├───aarch64-darwin
    │   └───default omitted (use '--all-systems' to show)
    ├───aarch64-linux
    │   └───default omitted (use '--all-systems' to show)
    ├───i686-linux
    │   └───default omitted (use '--all-systems' to show)
    ├───x86_64-darwin
    │   └───default omitted (use '--all-systems' to show)
    └───x86_64-linux
        └───default: development environment 'devshell'
```

And here are some questions:

- [ ] Should this be on by default?
  I think it should, but that would add flake outputs to existing users when they bump this input.
  Not sure that's acceptable in this community.
- [ ] Would adding this require also adding an option to enable this?
- [ ] This should also be documented when other questions are answered.
- [ ] Tests? Not sure I see any existing flake-module tests...
