### PR TITLE
fix(extra/language/c): should export LIBRARY_PATH as well

### DIFF
--- a/extra/language/c.nix
+++ b/extra/language/c.nix
@@ -52,6 +52,10 @@ with lib;
           name = "LDFLAGS";
           eval = "-L$DEVSHELL_DIR/lib";
         }
+        {
+          name = "LIBRARY_PATH";
+          eval = "-L$DEVSHELL_DIR/lib";
+        }
       ])
       ++ lib.optionals hasIncludes [
         {


### PR DESCRIPTION
gcc looks for `LIBRARY_PATH` for library search path[^1]

> LIBRARY_PATH
> 
> The value of LIBRARY_PATH is a colon-separated list of directories, much like PATH. When configured as a native compiler, GCC tries the directories thus specified when searching for special linker files, if it cannot find them using GCC_EXEC_PREFIX. Linking using GCC also uses these directories when searching for ordinary libraries for the -l option (but directories specified with -L come first).
> 

[^1]: https://gcc.gnu.org/onlinedocs/gcc-12.5.0/gcc/Environment-Variables.html#:~:text=LIBRARY_PATH