### PR TITLE
fix: support pure mode

### DIFF
--- a/extra/git/hooks.nix
+++ b/extra/git/hooks.nix
@@ -39,7 +39,7 @@ let
     mkdir -p $out/bin
 
     ${lib.concatMapStringsSep "\n" (k: ''
-      cat <<'WRAPPER' > $out/bin/${k}
+      ${pkgs.coreutils}/bin/cat <<'WRAPPER' > $out/bin/${k}
       #!${pkgs.bash}/bin/bash
       set -euo pipefail
 

--- a/extra/language/c.nix
+++ b/extra/language/c.nix
@@ -34,12 +34,13 @@ in
   };
 
   config = {
-    devshell.packages =
-      [ cfg.compiler ]
-      ++ (lib.optionals hasLibraries (map lib.getLib cfg.libraries))
-      ++
-        # Assume we want pkg-config, because it's good
-        (lib.optionals hasIncludes ([ pkgs.pkg-config ] ++ (map lib.getDev cfg.includes)));
+    devshell.packages = [
+      cfg.compiler
+    ]
+    ++ (lib.optionals hasLibraries (map lib.getLib cfg.libraries))
+    ++
+      # Assume we want pkg-config, because it's good
+      (lib.optionals hasIncludes ([ pkgs.pkg-config ] ++ (map lib.getDev cfg.includes)));
 
     env =
       (lib.optionals hasLibraries [

--- a/extra/language/rust.nix
+++ b/extra/language/rust.nix
@@ -37,53 +37,52 @@ in
   config = {
     devshell.packages =
       if cfg.enableDefaultToolchain then (map (tool: cfg.packageSet.${tool}) cfg.tools) else [ ];
-    env =
-      [
-        {
-          # On darwin for example enables finding of libiconv
-          name = "LIBRARY_PATH";
-          # append in case it needs to be modified
-          eval = "$DEVSHELL_DIR/lib";
-        }
-        {
-          # some *-sys crates require additional includes
-          name = "CFLAGS";
-          # append in case it needs to be modified
-          eval = "\"-I $DEVSHELL_DIR/include ${lib.optionalString pkgs.stdenv.isDarwin "-iframework $DEVSHELL_DIR/Library/Frameworks"}\"";
-        }
-      ]
-      ++ lib.optionals pkgs.stdenv.isDarwin [
-        {
-          # On darwin for example required for some *-sys crate compilation
-          name = "RUSTFLAGS";
-          # append in case it needs to be modified
-          eval = "\"-L framework=$DEVSHELL_DIR/Library/Frameworks\"";
-        }
-        {
-          # rustdoc uses a different set of flags
-          name = "RUSTDOCFLAGS";
-          # append in case it needs to be modified
-          eval = "\"-L framework=$DEVSHELL_DIR/Library/Frameworks\"";
-        }
-        {
-          name = "PATH";
-          prefix =
-            let
-              inherit (pkgs) xcbuild;
-            in
-            lib.makeBinPath [
-              xcbuild
-              "${xcbuild}/Toolchains/XcodeDefault.xctoolchain"
-            ];
-        }
-      ]
-      # fenix provides '.rust-src' in the 'complete' toolchain configuration
-      ++ lib.optionals (cfg.enableDefaultToolchain && cfg.packageSet ? rust-src) [
-        {
-          # rust-analyzer may use this to quicker find the rust source
-          name = "RUST_SRC_PATH";
-          value = "${cfg.packageSet.rust-src}/lib/rustlib/src/rust/library";
-        }
-      ];
+    env = [
+      {
+        # On darwin for example enables finding of libiconv
+        name = "LIBRARY_PATH";
+        # append in case it needs to be modified
+        eval = "$DEVSHELL_DIR/lib";
+      }
+      {
+        # some *-sys crates require additional includes
+        name = "CFLAGS";
+        # append in case it needs to be modified
+        eval = "\"-I $DEVSHELL_DIR/include ${lib.optionalString pkgs.stdenv.isDarwin "-iframework $DEVSHELL_DIR/Library/Frameworks"}\"";
+      }
+    ]
+    ++ lib.optionals pkgs.stdenv.isDarwin [
+      {
+        # On darwin for example required for some *-sys crate compilation
+        name = "RUSTFLAGS";
+        # append in case it needs to be modified
+        eval = "\"-L framework=$DEVSHELL_DIR/Library/Frameworks\"";
+      }
+      {
+        # rustdoc uses a different set of flags
+        name = "RUSTDOCFLAGS";
+        # append in case it needs to be modified
+        eval = "\"-L framework=$DEVSHELL_DIR/Library/Frameworks\"";
+      }
+      {
+        name = "PATH";
+        prefix =
+          let
+            inherit (pkgs) xcbuild;
+          in
+          lib.makeBinPath [
+            xcbuild
+            "${xcbuild}/Toolchains/XcodeDefault.xctoolchain"
+          ];
+      }
+    ]
+    # fenix provides '.rust-src' in the 'complete' toolchain configuration
+    ++ lib.optionals (cfg.enableDefaultToolchain && cfg.packageSet ? rust-src) [
+      {
+        # rust-analyzer may use this to quicker find the rust source
+        name = "RUST_SRC_PATH";
+        value = "${cfg.packageSet.rust-src}/lib/rustlib/src/rust/library";
+      }
+    ];
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
         {
           docs = pkgs.writeShellApplication {
             name = "docs";
-            meta.description = ''Run mdBook server at http://localhost:3000'';
+            meta.description = "Run mdBook server at http://localhost:3000";
             runtimeInputs = [ pkgs.mdbook ];
             text = ''
               cd docs
@@ -46,7 +46,7 @@
           };
           bench = pkgs.writeShellApplication {
             name = "benchmark";
-            meta.description = ''Run benchmark'';
+            meta.description = "Run benchmark";
             runtimeInputs = [ pkgs.hyperfine ];
             text = ''
               cd benchmark

--- a/modules/back-compat.nix
+++ b/modules/back-compat.nix
@@ -56,13 +56,12 @@ in
   };
 
   # Copy the values over to the devshell module
-  config.devshell =
-    {
-      packages = config.packages;
-      packagesFrom = config.packagesFrom;
-      startup.bash_extra = noDepEntry config.bash.extra;
-      interactive.bash_interactive = noDepEntry config.bash.interactive;
-    }
-    // (lib.optionalAttrs (config.motd != null) { motd = config.motd; })
-    // (lib.optionalAttrs (config.name != null) { name = config.name; });
+  config.devshell = {
+    packages = config.packages;
+    packagesFrom = config.packagesFrom;
+    startup.bash_extra = noDepEntry config.bash.extra;
+    interactive.bash_interactive = noDepEntry config.bash.interactive;
+  }
+  // (lib.optionalAttrs (config.motd != null) { motd = config.motd; })
+  // (lib.optionalAttrs (config.name != null) { name = config.name; });
 }

--- a/modules/commands.nix
+++ b/modules/commands.nix
@@ -179,7 +179,7 @@ in
       help = "prints this menu";
       name = "menu";
       command = ''
-        cat <<'DEVSHELL_MENU'
+        ${pkgs.coreutils}/bin/cat <<'DEVSHELL_MENU'
         ${commandsToMenu config.commands}
         DEVSHELL_MENU
       '';

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -173,7 +173,7 @@ let
     done
 
     if [[ -n "''${help:-}" ]]; then
-      cat <<USAGE
+      ${pkgs.coreutils}/bin/cat <<USAGE
     Usage: ${cfg.name}
       $0 -h | --help          # show this help
       $0 [--pure]             # start a bash sub-shell
@@ -397,7 +397,7 @@ in
       {
         motd = lib.noDepEntry ''
           __devshell-motd() {
-            cat <<DEVSHELL_PROMPT
+            ${pkgs.coreutils}/bin/cat <<DEVSHELL_PROMPT
           ${cfg.motd}
           DEVSHELL_PROMPT
           }

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -393,43 +393,42 @@ in
 
     packages = lib.foldl' (sum: drv: sum ++ (inputsOf drv)) [ ] cfg.packagesFrom;
 
-    startup =
-      {
-        motd = lib.noDepEntry ''
-          __devshell-motd() {
-            ${pkgs.coreutils}/bin/cat <<DEVSHELL_PROMPT
-          ${cfg.motd}
-          DEVSHELL_PROMPT
-          }
+    startup = {
+      motd = lib.noDepEntry ''
+        __devshell-motd() {
+          ${pkgs.coreutils}/bin/cat <<DEVSHELL_PROMPT
+        ${cfg.motd}
+        DEVSHELL_PROMPT
+        }
 
-          if [[ ''${DEVSHELL_NO_MOTD:-} = 1 ]]; then
-            # Skip if that env var is set
-            :
-          elif [[ ''${DIRENV_IN_ENVRC:-} = 1 ]]; then
-            # Print the motd in direnv
+        if [[ ''${DEVSHELL_NO_MOTD:-} = 1 ]]; then
+          # Skip if that env var is set
+          :
+        elif [[ ''${DIRENV_IN_ENVRC:-} = 1 ]]; then
+          # Print the motd in direnv
+          __devshell-motd
+        else
+          # Print information if the prompt is displayed. We have to make
+          # that distinction because `nix-shell -c "cmd"` is running in
+          # interactive mode.
+          __devshell-prompt() {
             __devshell-motd
-          else
-            # Print information if the prompt is displayed. We have to make
-            # that distinction because `nix-shell -c "cmd"` is running in
-            # interactive mode.
-            __devshell-prompt() {
-              __devshell-motd
-              # Make it a noop
-              __devshell-prompt() { :; }
-            }
-            PROMPT_COMMAND=__devshell-prompt''${PROMPT_COMMAND+;$PROMPT_COMMAND}
-          fi
-        '';
-      }
-      // (lib.optionalAttrs cfg.load_profiles {
-        load_profiles = lib.noDepEntry ''
-          # Load installed profiles
-          for file in "$DEVSHELL_DIR/etc/profile.d/"*.sh; do
-            # If that folder doesn't exist, bash loves to return the whole glob
-            [[ -f "$file" ]] && source "$file"
-          done
-        '';
-      });
+            # Make it a noop
+            __devshell-prompt() { :; }
+          }
+          PROMPT_COMMAND=__devshell-prompt''${PROMPT_COMMAND+;$PROMPT_COMMAND}
+        fi
+      '';
+    }
+    // (lib.optionalAttrs cfg.load_profiles {
+      load_profiles = lib.noDepEntry ''
+        # Load installed profiles
+        for file in "$DEVSHELL_DIR/etc/profile.d/"*.sh; do
+          # If that folder doesn't exist, bash loves to return the whole glob
+          [[ -f "$file" ]] && source "$file"
+        done
+      '';
+    });
 
     interactive = {
       PS1_util = lib.noDepEntry ''
@@ -472,7 +471,8 @@ in
         #  `lib.getExe`, `nix run`, `nix bundle`, etc.
         {
           mainProgram = cfg.package.meta.mainProgram;
-        } // cfg.meta;
+        }
+        // cfg.meta;
       profile = cfg.package;
       passthru = {
         inherit config;

--- a/modules/env.nix
+++ b/modules/env.nix
@@ -98,7 +98,7 @@ let
     else if valType == "prefix" then
       ''export ${name}=$(${pkgs.coreutils}/bin/realpath --canonicalize-missing "${prefix}")''${${name}+:''${${name}}}''
     else if valType == "unset" then
-      ''unset ${name}''
+      "unset ${name}"
     else
       throw "BUG in the env.nix module. This should never be reached.";
 in
@@ -143,7 +143,7 @@ in
       # This is used by bash-completions to find new completions on demand
       {
         name = "XDG_DATA_DIRS";
-        eval = ''$DEVSHELL_DIR/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}'';
+        eval = "$DEVSHELL_DIR/share:\${XDG_DATA_DIRS:-/usr/local/share:/usr/share}";
       }
 
       # A per-project data directory for runtime information.

--- a/modules/eval-args.nix
+++ b/modules/eval-args.nix
@@ -13,5 +13,6 @@ in
   specialArgs = {
     modulesPath = builtins.toString ./.;
     extraModulesPath = builtins.toString ../extra;
-  } // extraSpecialArgs;
+  }
+  // extraSpecialArgs;
 }

--- a/modules/services.nix
+++ b/modules/services.nix
@@ -96,7 +96,7 @@ let
         command =
           (pkgs.writeShellScript "${gName}-services-stop" ''
             if [ -e "$PRJ_DATA_DIR/pids/${gName}.pid" ]; then
-              pid=$(cat "$PRJ_DATA_DIR/pids/${gName}.pid")
+              pid=$(${pkgs.coreutils}/bin/cat "$PRJ_DATA_DIR/pids/${gName}.pid")
               kill -TERM $pid
               rm "$PRJ_DATA_DIR/pids/${gName}.pid"
             fi

--- a/nix/mkNakedShell.nix
+++ b/nix/mkNakedShell.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  runCommand,
   bashInteractive,
   coreutils,
   stdenv,
@@ -6,12 +8,22 @@
 }:
 let
   bashPath = "${bashInteractive}/bin/bash";
+  rmCommand = runCommand "coreutils-rm" { } ''
+    mkdir -p $out/bin
+    ln -s ${coreutils}/bin/rm $out/bin/rm
+  '';
   nakedStdenv = writeTextFile {
     name = "naked-stdenv";
     destination = "/setup";
     text = ''
       # Fix for `nix develop`
       : ''${outputs:=out}
+
+      # Fix for `nix-shell --pure` line 1: rm: command not found
+      # occurs at `_nix_shell_clean_tmpdir` in `nixos/nix`
+      ${lib.optionalString (builtins.getEnv "IN_NIX_SHELL" == "pure") ''
+        export PATH=${rmCommand}/bin:$PATH
+      ''}
 
       runHook() {
         eval "$shellHook"


### PR DESCRIPTION
Previously

```console
$ nix-shell
# prints menu
$ nix-shell --pure
/nix/store/...-devshell-dir/bin/menu: line 4: cat: command not found
bash: cat: command not found
$ nix-shell --pure --run 'exit'
/tmp/nix-shell-704775-1158748079/rc: line 1: rm: command not found
```

Now

```console
$ nix-shell --pure
# prints menu
[devshell]$
$ nix-shell --pure --run 'exit'
$ echo $?
0
```